### PR TITLE
Add relationship predicates (anyIn and anyEquals) and stringEquals

### DIFF
--- a/PeakCoreData/Helpers/NSPredicate.swift
+++ b/PeakCoreData/Helpers/NSPredicate.swift
@@ -214,11 +214,11 @@ extension NSPredicate {
     /// - Parameters:
     ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
     ///   - array: The array to check the relationship against.
-    public convenience init(anyIn value: [Any], keyPath: KeyPath? = nil) {
+    public convenience init(anyIncludedIn array: [Any], keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
-            self.init(format: "ANY %K IN %@", argumentArray: [keyPath, value])
+            self.init(format: "ANY %K IN %@", argumentArray: [keyPath, array])
         } else {
-            self.init(format: "ANY SELF IN %@", argumentArray: [value])
+            self.init(format: "ANY SELF IN %@", argumentArray: [array])
         }
     }
 }
@@ -227,7 +227,7 @@ extension NSPredicate {
 
 extension NSPredicate {
     
-    /// Returns a predicate that checks if a property is included in an array.
+    /// Returns a predicate that checks if a property is included in the passed in array.
     ///
     /// - Parameters:
     ///   - keyPath: The key path of the property. Pass in `nil` to use SELF.
@@ -240,7 +240,7 @@ extension NSPredicate {
         }
     }
     
-    /// Returns a predicate that checks if a property is not included in an array.
+    /// Returns a predicate that checks if a property is not included in the passed in array.
     ///
     /// - Parameters:
     ///   - keyPath: The key path of the property. Pass in `nil` to use SELF.

--- a/PeakCoreData/Helpers/NSPredicate.swift
+++ b/PeakCoreData/Helpers/NSPredicate.swift
@@ -17,7 +17,7 @@ extension NSPredicate {
     /// Returns a predicate that performs and equals comparison.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath to the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path to the property. Pass in `nil` to use SELF.
     ///   - value: The value to use in the comparison.
     public convenience init(equalTo value: Any?, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -38,7 +38,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a does not equal comparison.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath to the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path to the property. Pass in `nil` to use SELF.
     ///   - value: The value to use in the comparison.
     public convenience init(notEqualTo value: Any?, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -59,7 +59,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a less than comparison.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath to the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path to the property. Pass in `nil` to use SELF.
     ///   - value: The value to use in the comparison.
     public convenience init(lessThan value: Any, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -72,7 +72,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a less or equal to comparison.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath to the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path to the property. Pass in `nil` to use SELF.
     ///   - value: The value to use in the comparison.
     public convenience init(lessThanOrEqualTo value: Any, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -85,7 +85,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a greater than comparison.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath to the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path to the property. Pass in `nil` to use SELF.
     ///   - value: The value to use in the comparison.
     public convenience init(greaterThan value: Any, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -98,7 +98,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a greater than or equal to comparison.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath to the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path to the property. Pass in `nil` to use SELF.
     ///   - value: The value to use in the comparison.
     public convenience init(greaterThanOrEqualTo value: Any, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -116,7 +116,7 @@ extension NSPredicate {
     /// Returns a predicate that performs an equals comparison on a relationship count.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the entity relationship. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the entity relationship. Pass in `nil` to use SELF.
     ///   - count: The count to use in the comparison.
     public convenience init(countEqualTo count: Int, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -129,7 +129,7 @@ extension NSPredicate {
     /// Returns a predicate that performs an does not equal comparison on a relationship count.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the relationship. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
     ///   - count: The count to use in the comparison.
     public convenience init(countNotEqualTo count: Int, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -142,7 +142,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a less than comparison on a relationship count.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the relationship. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
     ///   - count: The count to use in the comparison.
     public convenience init(countLessThan value: Int, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -155,7 +155,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a less than or equal to comparison on a relationship count.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the relationship. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
     ///   - count: The count to use in the comparison.
     public convenience init(countLessThanOrEqualTo value: Int, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -168,7 +168,7 @@ extension NSPredicate {
     /// Returns a predicate that performs a greater than comparison on a relationship count.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the relationship. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
     ///   - count: The count to use in the comparison.
     public convenience init(countGreaterThan value: Int, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -181,13 +181,44 @@ extension NSPredicate {
     /// Returns a predicate that performs a greater than or equal to comparison on a relationship count.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the relationship. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
     ///   - count: The count to use in the comparison.
     public convenience init(countGreaterThanOrEqualTo value: Int, keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
             self.init(format: "%K.@count >= %@", argumentArray: [keyPath, value])
         } else {
             self.init(format: "SELF.@count >= %@", argumentArray: [value])
+        }
+    }
+}
+
+// MARK: - ANY
+
+extension NSPredicate {
+    
+    /// Returns a predicate that checks if any object in a relationship is equal to the passed in value.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
+    ///   - value: The value to check the relationship against.
+    public convenience init(anyEquals value: Any, keyPath: KeyPath? = nil) {
+        if let keyPath = keyPath {
+            self.init(format: "ANY %K == %@", argumentArray: [keyPath, value])
+        } else {
+            self.init(format: "ANY SELF == %@", argumentArray: [value])
+        }
+    }
+    
+    /// Returns a predicate that checks if any object in a relationship is included in the passed in array.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path of the relationship. Pass in `nil` to use SELF.
+    ///   - array: The array to check the relationship against.
+    public convenience init(anyIn value: [Any], keyPath: KeyPath? = nil) {
+        if let keyPath = keyPath {
+            self.init(format: "ANY %K IN %@", argumentArray: [keyPath, value])
+        } else {
+            self.init(format: "ANY SELF IN %@", argumentArray: [value])
         }
     }
 }
@@ -199,7 +230,7 @@ extension NSPredicate {
     /// Returns a predicate that checks if a property is included in an array.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the property. Pass in `nil` to use SELF.
     ///   - array: The array to check the value against.
     public convenience init(isIncludedIn array: [Any], keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -212,7 +243,7 @@ extension NSPredicate {
     /// Returns a predicate that checks if a property is not included in an array.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the property. Pass in `nil` to use SELF.
     ///   - array: The array to check the value against.
     public convenience init(isNotIncludedIn array: [Any], keyPath: KeyPath? = nil) {
         if let keyPath = keyPath {
@@ -227,42 +258,91 @@ extension NSPredicate {
 
 extension NSPredicate {
     
-    /// Returns a predicate that checks if a string property begins with another string.
+    /// Returns a predicate that checks if a string property begins with the passed in string.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the string property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the string property. Pass in `nil` to use SELF.
     ///   - string: The string to compare the property to.
-    public convenience init(stringBeginsWith string: String, keyPath: KeyPath? = nil) {
+    ///   - caseSensitive: If true, applies CaseInsensitive and DiacriticInsensitive flags ([cd]) to comparison. Default is true.
+    public convenience init(stringBeginsWith string: String, keyPath: KeyPath? = nil, caseInsensitive: Bool = true) {
         if let keyPath = keyPath {
-            self.init(format: "%K BEGINSWITH[cd] %@", argumentArray: [keyPath, string])
+            if caseInsensitive {
+                self.init(format: "%K BEGINSWITH[cd] %@", argumentArray: [keyPath, string])
+            } else {
+                self.init(format: "%K BEGINSWITH %@", argumentArray: [keyPath, string])
+            }
         } else {
-            self.init(format: "SELF BEGINSWITH[cd] %@", argumentArray: [string])
+            if caseInsensitive {
+                self.init(format: "SELF BEGINSWITH[cd] %@", argumentArray: [string])
+            } else {
+                self.init(format: "SELF BEGINSWITH %@", argumentArray: [string])
+            }
         }
     }
     
-    /// Returns a predicate that checks if a string property contains another string.
+    /// Returns a predicate that checks if a string property contains the passed in string.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the string property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the string property. Pass in `nil` to use SELF.
     ///   - string: The string to compare the property to.
-    public convenience init(stringContains string: String, keyPath: KeyPath? = nil) {
+    ///   - caseSensitive: If true, applies CaseInsensitive and DiacriticInsensitive flags ([cd]) to comparison. Default is true.
+    public convenience init(stringContains string: String, keyPath: KeyPath? = nil, caseInsensitive: Bool = true) {
         if let keyPath = keyPath {
-            self.init(format: "%K CONTAINS[cd] %@", argumentArray: [keyPath, string])
+            if caseInsensitive {
+                self.init(format: "%K CONTAINS[cd] %@", argumentArray: [keyPath, string])
+            } else {
+                self.init(format: "%K CONTAINS %@", argumentArray: [keyPath, string])
+            }
         } else {
-            self.init(format: "SELF CONTAINS[cd] %@", argumentArray: [string])
+            if caseInsensitive {
+                self.init(format: "SELF CONTAINS[cd] %@", argumentArray: [string])
+            } else {
+                self.init(format: "SELF CONTAINS %@", argumentArray: [string])
+            }
         }
     }
     
-    /// Returns a predicate that checks if a string property ends with another string.
+    /// Returns a predicate that checks if a string property equals the passed in string.
     ///
     /// - Parameters:
-    ///   - keyPath: The keypath of the string property. Pass in `nil` to use SELF.
+    ///   - keyPath: The key path of the string property. Pass in `nil` to use SELF.
     ///   - string: The string to compare the property to.
-    public convenience init(stringEndsWith string: String, keyPath: KeyPath? = nil) {
+    ///   - caseSensitive: If true, applies CaseInsensitive and DiacriticInsensitive flags ([cd]) to comparison. Default is true.
+    public convenience init(stringEquals string: String, keyPath: KeyPath? = nil, caseInsensitive: Bool = true) {
         if let keyPath = keyPath {
-            self.init(format: "%K ENDSWITH[cd] %@", argumentArray: [keyPath, string])
+            if caseInsensitive {
+                self.init(format: "%K ==[cd] %@", argumentArray: [keyPath, string])
+            } else {
+                self.init(format: "%K == %@", argumentArray: [keyPath, string])
+            }
         } else {
-            self.init(format: "SELF ENDSWITH[cd] %@", argumentArray: [string])
+            if caseInsensitive {
+                self.init(format: "SELF ==[cd] %@", argumentArray: [string])
+            } else {
+                self.init(format: "SELF == %@", argumentArray: [string])
+            }
+        }
+    }
+    
+    /// Returns a predicate that checks if a string property ends with the passed in string.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The key path of the string property. Pass in `nil` to use SELF.
+    ///   - string: The string to compare the property to.
+    ///   - caseSensitive: If true, applies CaseInsensitive and DiacriticInsensitive flags ([cd]) to comparison. Default is true.
+    public convenience init(stringEndsWith string: String, keyPath: KeyPath? = nil, caseInsensitive: Bool = true) {
+        if let keyPath = keyPath {
+            if caseInsensitive {
+                self.init(format: "%K ENDSWITH[cd] %@", argumentArray: [keyPath, string])
+            } else {
+                self.init(format: "%K ENDSWITH %@", argumentArray: [keyPath, string])
+            }
+        } else {
+            if caseInsensitive {
+                self.init(format: "SELF ENDSWITH[cd] %@", argumentArray: [string])
+            } else {
+                self.init(format: "SELF ENDSWITH %@", argumentArray: [string])
+            }
         }
     }
 }

--- a/PeakCoreDataTests/PredicateTests.swift
+++ b/PeakCoreDataTests/PredicateTests.swift
@@ -251,12 +251,12 @@ class PredicateTests: XCTestCase {
     }
     
     func testAnyIn() {
-        let selfPredicate = NSPredicate(anyIn: [object2, object3])
+        let selfPredicate = NSPredicate(anyIncludedIn: [object2, object3])
         XCTAssertFalse(selfPredicate.evaluate(with: oneObject))
         XCTAssertTrue(selfPredicate.evaluate(with: twoObjects))
         XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
         
-        let keyPathPredicate = NSPredicate(anyIn: [object2, object3], keyPath: #keyPath(Parent.children))
+        let keyPathPredicate = NSPredicate(anyIncludedIn: [object2, object3], keyPath: #keyPath(Parent.children))
         XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
         XCTAssertTrue(keyPathPredicate.evaluate(with: twoChildren))
         XCTAssertTrue(keyPathPredicate.evaluate(with: threeChildren))
@@ -268,7 +268,7 @@ class PredicateTests: XCTestCase {
     }
     
     func testAnyInNested() {
-        let keyPathPredicate = NSPredicate(anyIn: [3, 2], keyPath: #keyPath(Parent.children.count))
+        let keyPathPredicate = NSPredicate(anyIncludedIn: [3, 2], keyPath: #keyPath(Parent.children.count))
         XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
         XCTAssertTrue(keyPathPredicate.evaluate(with: twoChildren))
         XCTAssertTrue(keyPathPredicate.evaluate(with: threeChildren))

--- a/PeakCoreDataTests/PredicateTests.swift
+++ b/PeakCoreDataTests/PredicateTests.swift
@@ -47,10 +47,15 @@ class PredicateTests: XCTestCase {
         XCTAssertFalse(selfPredicate.evaluate(with: object2))
         XCTAssertFalse(selfPredicate.evaluate(with: object3))
         
-        let keyPathPredicate = NSPredicate(equalTo: "ABC Object 1", keyPath: #keyPath(Object.name))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: object1))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
+        let stringPredicate = NSPredicate(equalTo: "ABC Object 1", keyPath: #keyPath(Object.name))
+        XCTAssertTrue(stringPredicate.evaluate(with: object1))
+        XCTAssertFalse(stringPredicate.evaluate(with: object2))
+        XCTAssertFalse(stringPredicate.evaluate(with: object3))
+        
+        let countPredicate = NSPredicate(equalTo: 3, keyPath: #keyPath(Object.count))
+        XCTAssertFalse(countPredicate.evaluate(with: object1))
+        XCTAssertTrue(countPredicate.evaluate(with: object2))
+        XCTAssertFalse(countPredicate.evaluate(with: object3))
     }
     
     func testNotEqualTo() {
@@ -59,10 +64,15 @@ class PredicateTests: XCTestCase {
         XCTAssertTrue(selfPredicate.evaluate(with: object2))
         XCTAssertTrue(selfPredicate.evaluate(with: object3))
         
-        let keyPathPredicate = NSPredicate(notEqualTo: "ABC Object 1", keyPath: #keyPath(Object.name))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: object3))
+        let stringPredicate = NSPredicate(notEqualTo: "ABC Object 1", keyPath: #keyPath(Object.name))
+        XCTAssertFalse(stringPredicate.evaluate(with: object1))
+        XCTAssertTrue(stringPredicate.evaluate(with: object2))
+        XCTAssertTrue(stringPredicate.evaluate(with: object3))
+        
+        let countPredicate = NSPredicate(notEqualTo: 3, keyPath: #keyPath(Object.count))
+        XCTAssertTrue(countPredicate.evaluate(with: object1))
+        XCTAssertFalse(countPredicate.evaluate(with: object2))
+        XCTAssertTrue(countPredicate.evaluate(with: object3))
     }
     
     func testLessThan() {
@@ -217,10 +227,10 @@ class PredicateTests: XCTestCase {
         XCTAssertFalse(selfPredicate.evaluate(with: twoObjects))
         XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
         
-        let predicate = NSPredicate(anyEquals: object3, keyPath: #keyPath(Parent.children))
-        XCTAssertFalse(predicate.evaluate(with: oneChild))
-        XCTAssertFalse(predicate.evaluate(with: twoChildren))
-        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        let keyPathPredicate = NSPredicate(anyEquals: object3, keyPath: #keyPath(Parent.children))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: twoChildren))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: threeChildren))
         
         let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child == %@)).@count > 0", argumentArray: [#keyPath(Parent.children), object3])
         XCTAssertFalse(subquery.evaluate(with: oneChild))
@@ -229,10 +239,10 @@ class PredicateTests: XCTestCase {
     }
     
     func testAnyEqualsNested() {
-        let predicate = NSPredicate(anyEquals: 3, keyPath: #keyPath(Parent.children.count))
-        XCTAssertFalse(predicate.evaluate(with: oneChild))
-        XCTAssertTrue(predicate.evaluate(with: twoChildren))
-        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        let keyPathPredicate = NSPredicate(anyEquals: 3, keyPath: #keyPath(Parent.children.count))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: twoChildren))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: threeChildren))
         
         let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child.%K == %@)).@count > 0", argumentArray: [#keyPath(Parent.children), #keyPath(Object.count), 3])
         XCTAssertFalse(subquery.evaluate(with: oneChild))
@@ -246,10 +256,10 @@ class PredicateTests: XCTestCase {
         XCTAssertTrue(selfPredicate.evaluate(with: twoObjects))
         XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
         
-        let predicate = NSPredicate(anyIn: [object2, object3], keyPath: #keyPath(Parent.children))
-        XCTAssertFalse(predicate.evaluate(with: oneChild))
-        XCTAssertTrue(predicate.evaluate(with: twoChildren))
-        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        let keyPathPredicate = NSPredicate(anyIn: [object2, object3], keyPath: #keyPath(Parent.children))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: twoChildren))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: threeChildren))
         
         let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child IN %@)).@count > 0", argumentArray: [#keyPath(Parent.children), [object2, object3]])
         XCTAssertFalse(subquery.evaluate(with: oneChild))
@@ -258,10 +268,10 @@ class PredicateTests: XCTestCase {
     }
     
     func testAnyInNested() {
-        let predicate = NSPredicate(anyIn: [3, 2], keyPath: #keyPath(Parent.children.count))
-        XCTAssertFalse(predicate.evaluate(with: oneChild))
-        XCTAssertTrue(predicate.evaluate(with: twoChildren))
-        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        let keyPathPredicate = NSPredicate(anyIn: [3, 2], keyPath: #keyPath(Parent.children.count))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: twoChildren))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: threeChildren))
         
         let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child.%K IN %@)).@count > 0", argumentArray: [#keyPath(Parent.children), #keyPath(Object.count), [3, 2]])
         XCTAssertFalse(subquery.evaluate(with: oneChild))

--- a/PeakCoreDataTests/PredicateTests.swift
+++ b/PeakCoreDataTests/PredicateTests.swift
@@ -318,7 +318,7 @@ class PredicateTests: XCTestCase {
         XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
-    func testStringBeginsWithCaseSsensitive() {
+    func testStringBeginsWithCaseSensitive() {
         let testString = "def"
         let selfPredicate = NSPredicate(stringBeginsWith: testString, caseInsensitive: false)
         XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
@@ -344,7 +344,7 @@ class PredicateTests: XCTestCase {
         XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
-    func testStringEqualsCaseSsensitive() {
+    func testStringEqualsCaseSensitive() {
         let testString = "def object 2"
         let selfPredicate = NSPredicate(stringEquals: testString, caseInsensitive: false)
         XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
@@ -370,7 +370,7 @@ class PredicateTests: XCTestCase {
         XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
-    func testStringEndsWithCaseSsensitive() {
+    func testStringEndsWithCaseSensitive() {
         let testString = "ECT 2"
         let selfPredicate = NSPredicate(stringEndsWith: testString, caseInsensitive: false)
         XCTAssertFalse(selfPredicate.evaluate(with: object1.name))

--- a/PeakCoreDataTests/PredicateTests.swift
+++ b/PeakCoreDataTests/PredicateTests.swift
@@ -31,93 +31,93 @@ class PredicateTests: XCTestCase {
         }
     }
     
-    lazy var jam = Object(name: "Jam", count: 4)
-    lazy var elephants = Object(name: "Elephants", count: 3)
-    lazy var peanuts = Object(name: "Peanuts", count: 2)
-    lazy var oneItem = [jam]
-    lazy var twoItems = [jam, elephants]
-    lazy var threeItems = [jam, elephants, peanuts]
-    lazy var oneChild = Parent(children: oneItem)
-    lazy var twoChildren = Parent(children: twoItems)
-    lazy var threeChildren = Parent(children: threeItems)
+    lazy var object1 = Object(name: "ABC Object 1", count: 4)
+    lazy var object2 = Object(name: "DEF Object 2", count: 3)
+    lazy var object3 = Object(name: "GHI Object 3", count: 2)
+    lazy var oneObject = [object1]
+    lazy var twoObjects = [object1, object2]
+    lazy var threeObjects = [object1, object2, object3]
+    lazy var oneChild = Parent(children: oneObject)
+    lazy var twoChildren = Parent(children: twoObjects)
+    lazy var threeChildren = Parent(children: threeObjects)
     
     func testEqualTo() {
-        let selfPredicate = NSPredicate(equalTo: jam)
-        XCTAssertTrue(selfPredicate.evaluate(with: jam))
-        XCTAssertFalse(selfPredicate.evaluate(with: elephants))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts))
+        let selfPredicate = NSPredicate(equalTo: object1)
+        XCTAssertTrue(selfPredicate.evaluate(with: object1))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3))
         
-        let keyPathPredicate = NSPredicate(equalTo: "Jam", keyPath: #keyPath(Object.name))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: jam))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        let keyPathPredicate = NSPredicate(equalTo: "ABC Object 1", keyPath: #keyPath(Object.name))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
     func testNotEqualTo() {
-        let selfPredicate = NSPredicate(notEqualTo: jam)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants))
-        XCTAssertTrue(selfPredicate.evaluate(with: peanuts))
+        let selfPredicate = NSPredicate(notEqualTo: object1)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2))
+        XCTAssertTrue(selfPredicate.evaluate(with: object3))
         
-        let keyPathPredicate = NSPredicate(notEqualTo: "Jam", keyPath: #keyPath(Object.name))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: peanuts))
+        let keyPathPredicate = NSPredicate(notEqualTo: "ABC Object 1", keyPath: #keyPath(Object.name))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object3))
     }
     
     func testLessThan() {
         let selfPredicate = NSPredicate(lessThan: 3)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam.count))
-        XCTAssertFalse(selfPredicate.evaluate(with: elephants.count))
-        XCTAssertTrue(selfPredicate.evaluate(with: peanuts.count))
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.count))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2.count))
+        XCTAssertTrue(selfPredicate.evaluate(with: object3.count))
         
         let keyPathPredicate = NSPredicate(lessThan: 3, keyPath: #keyPath(Object.count))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object3))
     }
     
     func testLessThanOrEqualTo() {
         let selfPredicate = NSPredicate(lessThanOrEqualTo: 3)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam.count))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants.count))
-        XCTAssertTrue(selfPredicate.evaluate(with: peanuts.count))
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.count))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2.count))
+        XCTAssertTrue(selfPredicate.evaluate(with: object3.count))
         
         let keyPathPredicate = NSPredicate(lessThanOrEqualTo: 3, keyPath: #keyPath(Object.count))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object3))
     }
     
     func testGreaterThan() {
         let selfPredicate = NSPredicate(greaterThan: 3)
-        XCTAssertTrue(selfPredicate.evaluate(with: jam.count))
-        XCTAssertFalse(selfPredicate.evaluate(with: elephants.count))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts.count))
+        XCTAssertTrue(selfPredicate.evaluate(with: object1.count))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2.count))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.count))
         
         let keyPathPredicate = NSPredicate(greaterThan: 3, keyPath: #keyPath(Object.count))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: jam))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
     func testGreaterThanOrEqualTo() {
         let selfPredicate = NSPredicate(greaterThanOrEqualTo: 3)
-        XCTAssertTrue(selfPredicate.evaluate(with: jam.count))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants.count))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts.count))
+        XCTAssertTrue(selfPredicate.evaluate(with: object1.count))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2.count))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.count))
         
         let keyPathPredicate = NSPredicate(greaterThanOrEqualTo: 3, keyPath: #keyPath(Object.count))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
     func testCountEqualTo() {
         let selfPredicate = NSPredicate(countEqualTo: 3)
-        XCTAssertFalse(selfPredicate.evaluate(with: oneItem))
-        XCTAssertFalse(selfPredicate.evaluate(with: twoItems))
-        XCTAssertTrue(selfPredicate.evaluate(with: threeItems))
+        XCTAssertFalse(selfPredicate.evaluate(with: oneObject))
+        XCTAssertFalse(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
         
         let keyPathPredicate = NSPredicate(countEqualTo: 3, keyPath: #keyPath(Parent.children))
         XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
@@ -127,9 +127,9 @@ class PredicateTests: XCTestCase {
     
     func testCountNotEqualTo() {
         let selfPredicate = NSPredicate(countNotEqualTo: 3)
-        XCTAssertTrue(selfPredicate.evaluate(with: oneItem))
-        XCTAssertTrue(selfPredicate.evaluate(with: twoItems))
-        XCTAssertFalse(selfPredicate.evaluate(with: threeItems))
+        XCTAssertTrue(selfPredicate.evaluate(with: oneObject))
+        XCTAssertTrue(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertFalse(selfPredicate.evaluate(with: threeObjects))
         
         let keyPathPredicate = NSPredicate(countNotEqualTo: 3, keyPath: #keyPath(Parent.children))
         XCTAssertTrue(keyPathPredicate.evaluate(with: oneChild))
@@ -139,9 +139,9 @@ class PredicateTests: XCTestCase {
     
     func testCountLessThan() {
         let selfPredicate = NSPredicate(countLessThan: 2)
-        XCTAssertTrue(selfPredicate.evaluate(with: oneItem))
-        XCTAssertFalse(selfPredicate.evaluate(with: twoItems))
-        XCTAssertFalse(selfPredicate.evaluate(with: threeItems))
+        XCTAssertTrue(selfPredicate.evaluate(with: oneObject))
+        XCTAssertFalse(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertFalse(selfPredicate.evaluate(with: threeObjects))
         
         let keyPathPredicate = NSPredicate(countLessThan: 2, keyPath: #keyPath(Parent.children))
         XCTAssertTrue(keyPathPredicate.evaluate(with: oneChild))
@@ -151,9 +151,9 @@ class PredicateTests: XCTestCase {
     
     func testCountLessThanOrEqualTo() {
         let selfPredicate = NSPredicate(countLessThanOrEqualTo: 2)
-        XCTAssertTrue(selfPredicate.evaluate(with: oneItem))
-        XCTAssertTrue(selfPredicate.evaluate(with: twoItems))
-        XCTAssertFalse(selfPredicate.evaluate(with: threeItems))
+        XCTAssertTrue(selfPredicate.evaluate(with: oneObject))
+        XCTAssertTrue(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertFalse(selfPredicate.evaluate(with: threeObjects))
         
         let keyPathPredicate = NSPredicate(countLessThanOrEqualTo: 2, keyPath: #keyPath(Parent.children))
         XCTAssertTrue(keyPathPredicate.evaluate(with: oneChild))
@@ -163,9 +163,9 @@ class PredicateTests: XCTestCase {
     
     func testCountGreaterThan() {
         let selfPredicate = NSPredicate(countGreaterThan: 2)
-        XCTAssertFalse(selfPredicate.evaluate(with: oneItem))
-        XCTAssertFalse(selfPredicate.evaluate(with: twoItems))
-        XCTAssertTrue(selfPredicate.evaluate(with: threeItems))
+        XCTAssertFalse(selfPredicate.evaluate(with: oneObject))
+        XCTAssertFalse(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
         
         let keyPathPredicate = NSPredicate(countGreaterThan: 2, keyPath: #keyPath(Parent.children))
         XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
@@ -175,9 +175,9 @@ class PredicateTests: XCTestCase {
     
     func testCountGreaterThanOrEqualTo() {
         let selfPredicate = NSPredicate(countGreaterThanOrEqualTo: 2)
-        XCTAssertFalse(selfPredicate.evaluate(with: oneItem))
-        XCTAssertTrue(selfPredicate.evaluate(with: twoItems))
-        XCTAssertTrue(selfPredicate.evaluate(with: threeItems))
+        XCTAssertFalse(selfPredicate.evaluate(with: oneObject))
+        XCTAssertTrue(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
         
         let keyPathPredicate = NSPredicate(countGreaterThanOrEqualTo: 2, keyPath: #keyPath(Parent.children))
         XCTAssertFalse(keyPathPredicate.evaluate(with: oneChild))
@@ -186,67 +186,190 @@ class PredicateTests: XCTestCase {
     }
     
     func testIsIncludedIn() {
-        let selfPredicate = NSPredicate(isIncludedIn: twoItems)
-        XCTAssertTrue(selfPredicate.evaluate(with: jam))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts))
+        let selfPredicate = NSPredicate(isIncludedIn: twoObjects)
+        XCTAssertTrue(selfPredicate.evaluate(with: object1))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3))
         
-        let array = twoItems.map { $0.name }
+        let array = twoObjects.map { $0.name }
         let keyPathPredicate = NSPredicate(isIncludedIn: array, keyPath: #keyPath(Object.name))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
     func testIsNotIncludedIn() {
-        let selfPredicate = NSPredicate(isNotIncludedIn: twoItems)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam))
-        XCTAssertFalse(selfPredicate.evaluate(with: elephants))
-        XCTAssertTrue(selfPredicate.evaluate(with: peanuts))
+        let selfPredicate = NSPredicate(isNotIncludedIn: twoObjects)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2))
+        XCTAssertTrue(selfPredicate.evaluate(with: object3))
         
-        let array = twoItems.map { $0.name }
+        let array = twoObjects.map { $0.name }
         let keyPathPredicate = NSPredicate(isNotIncludedIn: array, keyPath: #keyPath(Object.name))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object3))
+    }
+    
+    func testAnyEquals() {
+        let selfPredicate = NSPredicate(anyEquals: object3)
+        XCTAssertFalse(selfPredicate.evaluate(with: oneObject))
+        XCTAssertFalse(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
+        
+        let predicate = NSPredicate(anyEquals: object3, keyPath: #keyPath(Parent.children))
+        XCTAssertFalse(predicate.evaluate(with: oneChild))
+        XCTAssertFalse(predicate.evaluate(with: twoChildren))
+        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        
+        let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child == %@)).@count > 0", argumentArray: [#keyPath(Parent.children), object3])
+        XCTAssertFalse(subquery.evaluate(with: oneChild))
+        XCTAssertFalse(subquery.evaluate(with: twoChildren))
+        XCTAssertTrue(subquery.evaluate(with: threeChildren))
+    }
+    
+    func testAnyEqualsNested() {
+        let predicate = NSPredicate(anyEquals: 3, keyPath: #keyPath(Parent.children.count))
+        XCTAssertFalse(predicate.evaluate(with: oneChild))
+        XCTAssertTrue(predicate.evaluate(with: twoChildren))
+        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        
+        let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child.%K == %@)).@count > 0", argumentArray: [#keyPath(Parent.children), #keyPath(Object.count), 3])
+        XCTAssertFalse(subquery.evaluate(with: oneChild))
+        XCTAssertTrue(subquery.evaluate(with: twoChildren))
+        XCTAssertTrue(subquery.evaluate(with: threeChildren))
+    }
+    
+    func testAnyIn() {
+        let selfPredicate = NSPredicate(anyIn: [object2, object3])
+        XCTAssertFalse(selfPredicate.evaluate(with: oneObject))
+        XCTAssertTrue(selfPredicate.evaluate(with: twoObjects))
+        XCTAssertTrue(selfPredicate.evaluate(with: threeObjects))
+        
+        let predicate = NSPredicate(anyIn: [object2, object3], keyPath: #keyPath(Parent.children))
+        XCTAssertFalse(predicate.evaluate(with: oneChild))
+        XCTAssertTrue(predicate.evaluate(with: twoChildren))
+        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        
+        let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child IN %@)).@count > 0", argumentArray: [#keyPath(Parent.children), [object2, object3]])
+        XCTAssertFalse(subquery.evaluate(with: oneChild))
+        XCTAssertTrue(subquery.evaluate(with: twoChildren))
+        XCTAssertTrue(subquery.evaluate(with: threeChildren))
+    }
+    
+    func testAnyInNested() {
+        let predicate = NSPredicate(anyIn: [3, 2], keyPath: #keyPath(Parent.children.count))
+        XCTAssertFalse(predicate.evaluate(with: oneChild))
+        XCTAssertTrue(predicate.evaluate(with: twoChildren))
+        XCTAssertTrue(predicate.evaluate(with: threeChildren))
+        
+        let subquery = NSPredicate(format: "SUBQUERY(%K, $child, ($child.%K IN %@)).@count > 0", argumentArray: [#keyPath(Parent.children), #keyPath(Object.count), [3, 2]])
+        XCTAssertFalse(subquery.evaluate(with: oneChild))
+        XCTAssertTrue(subquery.evaluate(with: twoChildren))
+        XCTAssertTrue(subquery.evaluate(with: threeChildren))
     }
     
     func testStringContains() {
-        let testString = "eph"
+        let testString = "JECT 2"
         let selfPredicate = NSPredicate(stringContains: testString)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam.name))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants.name))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
         
         let keyPathPredicate = NSPredicate(stringContains: testString, keyPath: #keyPath(Object.name))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
+    }
+    
+    func testStringContainsCaseSensitive() {
+        let testString = "JECT 2"
+        let selfPredicate = NSPredicate(stringContains: testString, caseInsensitive: false)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
+        
+        let keyPathPredicate = NSPredicate(stringContains: testString, keyPath: #keyPath(Object.name), caseInsensitive: false)
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
     func testStringBeginsWith() {
-        let testString = "ele"
+        let testString = "def"
         let selfPredicate = NSPredicate(stringBeginsWith: testString)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam.name))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants.name))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
         
         let keyPathPredicate = NSPredicate(stringBeginsWith: testString, keyPath: #keyPath(Object.name))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
+    }
+    
+    func testStringBeginsWithCaseSsensitive() {
+        let testString = "def"
+        let selfPredicate = NSPredicate(stringBeginsWith: testString, caseInsensitive: false)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
+        
+        let keyPathPredicate = NSPredicate(stringBeginsWith: testString, keyPath: #keyPath(Object.name), caseInsensitive: false)
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
+    }
+    
+    func testStringEquals() {
+        let testString = "def object 2"
+        let selfPredicate = NSPredicate(stringEquals: testString)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
+        
+        let keyPathPredicate = NSPredicate(stringEquals: testString, keyPath: #keyPath(Object.name))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
+    }
+    
+    func testStringEqualsCaseSsensitive() {
+        let testString = "def object 2"
+        let selfPredicate = NSPredicate(stringEquals: testString, caseInsensitive: false)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
+        
+        let keyPathPredicate = NSPredicate(stringEquals: testString, keyPath: #keyPath(Object.name), caseInsensitive: false)
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
     
     func testStringEndsWith() {
-        let testString = "nts"
+        let testString = "ECT 2"
         let selfPredicate = NSPredicate(stringEndsWith: testString)
-        XCTAssertFalse(selfPredicate.evaluate(with: jam.name))
-        XCTAssertTrue(selfPredicate.evaluate(with: elephants.name))
-        XCTAssertFalse(selfPredicate.evaluate(with: peanuts.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertTrue(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
         
         let keyPathPredicate = NSPredicate(stringEndsWith: testString, keyPath: #keyPath(Object.name))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: jam))
-        XCTAssertTrue(keyPathPredicate.evaluate(with: elephants))
-        XCTAssertFalse(keyPathPredicate.evaluate(with: peanuts))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertTrue(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
+    }
+    
+    func testStringEndsWithCaseSsensitive() {
+        let testString = "ECT 2"
+        let selfPredicate = NSPredicate(stringEndsWith: testString, caseInsensitive: false)
+        XCTAssertFalse(selfPredicate.evaluate(with: object1.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object2.name))
+        XCTAssertFalse(selfPredicate.evaluate(with: object3.name))
+        
+        let keyPathPredicate = NSPredicate(stringEndsWith: testString, keyPath: #keyPath(Object.name), caseInsensitive: false)
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object1))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object2))
+        XCTAssertFalse(keyPathPredicate.evaluate(with: object3))
     }
 }


### PR DESCRIPTION
Additional predicate initialisers and unit tests, including:

`NSPredicate(format: "ANY %K == %@", argumentArray: [keyPath, value])`
`NSPredicate(format: "ANY %K IN %@", argumentArray: [keyPath, value])`
`NSPredicate(format: "SELF ==[cd] %@", argumentArray: [string])`

Also added a flag to allow case sensitive comparison of strings