### PR TITLE
Feature/batch operations

### DIFF
--- a/PeakCoreData.xcodeproj/project.pbxproj
+++ b/PeakCoreData.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		6346D9F224360C8400521E6C /* ManagedObjectCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346D9F124360C8400521E6C /* ManagedObjectCache.swift */; };
 		6346D9F72436246D00521E6C /* ManagedObjectCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346D9F62436246D00521E6C /* ManagedObjectCacheTests.swift */; };
 		6346D9F82436246D00521E6C /* ManagedObjectCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346D9F62436246D00521E6C /* ManagedObjectCacheTests.swift */; };
+		636619A32476B361008E573D /* CoreDataBatchUpdateOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A22476B361008E573D /* CoreDataBatchUpdateOperation.swift */; };
+		636619A52476B36D008E573D /* CoreDataBatchDeleteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A42476B36D008E573D /* CoreDataBatchDeleteOperation.swift */; };
+		636619A62476B38F008E573D /* CoreDataBatchDeleteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A42476B36D008E573D /* CoreDataBatchDeleteOperation.swift */; };
+		636619A72476B395008E573D /* CoreDataBatchUpdateOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A22476B361008E573D /* CoreDataBatchUpdateOperation.swift */; };
 		8D05BE6D2051518B00DE93AC /* FetchedDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D05BE6C2051518B00DE93AC /* FetchedDataProvider.swift */; };
 		8D159AFE205C001A004D693A /* AnotherEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D159AFD205C001A004D693A /* AnotherEntity.swift */; };
 		8D159B00205C01EE004D693A /* ContextDidSaveNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D159AFF205C01EE004D693A /* ContextDidSaveNotification.swift */; };
@@ -132,6 +136,8 @@
 		6346D9EF24360C4700521E6C /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		6346D9F124360C8400521E6C /* ManagedObjectCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedObjectCache.swift; sourceTree = "<group>"; };
 		6346D9F62436246D00521E6C /* ManagedObjectCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedObjectCacheTests.swift; sourceTree = "<group>"; };
+		636619A22476B361008E573D /* CoreDataBatchUpdateOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataBatchUpdateOperation.swift; sourceTree = "<group>"; };
+		636619A42476B36D008E573D /* CoreDataBatchDeleteOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataBatchDeleteOperation.swift; sourceTree = "<group>"; };
 		6F1222CBE402AC7FD0C7226D /* Pods-PeakCoreData-macOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PeakCoreData-macOSTests.debug.xcconfig"; path = "Target Support Files/Pods-PeakCoreData-macOSTests/Pods-PeakCoreData-macOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		700FD15F5FA7E5B1E735EE88 /* Pods-PeakCoreData-iOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PeakCoreData-iOSTests.release.xcconfig"; path = "Target Support Files/Pods-PeakCoreData-iOSTests/Pods-PeakCoreData-iOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		8D05BE6C2051518B00DE93AC /* FetchedDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchedDataProvider.swift; sourceTree = "<group>"; };
@@ -365,9 +371,11 @@
 			isa = PBXGroup;
 			children = (
 				8DFAC1101F79274B0015EDC0 /* Changeset.swift */,
-				CBF972A41E5DEE6D00F37801 /* CoreDataOperation.swift */,
-				8DDAE2982056E113001D7521 /* CoreDataChangesetOperation.swift */,
+				636619A42476B36D008E573D /* CoreDataBatchDeleteOperation.swift */,
 				CBF972BC1E5DEF2900F37801 /* CoreDataBatchImportOperation.swift */,
+				636619A22476B361008E573D /* CoreDataBatchUpdateOperation.swift */,
+				8DDAE2982056E113001D7521 /* CoreDataChangesetOperation.swift */,
+				CBF972A41E5DEE6D00F37801 /* CoreDataOperation.swift */,
 				8DFAC10E1F7918420015EDC0 /* CoreDataSingleImportOperation.swift */,
 				8D84C262224CD83C008C35D7 /* CoreDataToIntermediateOperation.swift */,
 			);
@@ -731,6 +739,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				636619A72476B395008E573D /* CoreDataBatchUpdateOperation.swift in Sources */,
 				186D313A22CB849E003A5A8F /* FetchedDataProvider.swift in Sources */,
 				186D312822CB651C003A5A8F /* ObjectDidChangeNotification.swift in Sources */,
 				186D313522CB669E003A5A8F /* UniqueIdentifiable.swift in Sources */,
@@ -744,6 +753,7 @@
 				186D312622CB6519003A5A8F /* ManagedObjectObserver.swift in Sources */,
 				186D312422CB6510003A5A8F /* NSPredicate.swift in Sources */,
 				186D311F22CB650B003A5A8F /* FetchedCollection.swift in Sources */,
+				636619A62476B38F008E573D /* CoreDataBatchDeleteOperation.swift in Sources */,
 				186D312322CB6510003A5A8F /* NSManagedObjectContext.swift in Sources */,
 				18CD62BA22E8A327004F3E93 /* NSEntityDescription.swift in Sources */,
 				186D313422CB669E003A5A8F /* PersistentContainerSettable.swift in Sources */,
@@ -785,9 +795,11 @@
 				8DDAE2992056E113001D7521 /* CoreDataChangesetOperation.swift in Sources */,
 				CBF972B51E5DEEFC00F37801 /* PersistentContainerSettable.swift in Sources */,
 				CBF972B21E5DEE8700F37801 /* ManagedObjectType.swift in Sources */,
+				636619A52476B36D008E573D /* CoreDataBatchDeleteOperation.swift in Sources */,
 				18CD62B922E8A327004F3E93 /* NSEntityDescription.swift in Sources */,
 				8DFAC10F1F7918420015EDC0 /* CoreDataSingleImportOperation.swift in Sources */,
 				8D6B966F20501D87003D20C0 /* FetchedTableViewDataSource.swift in Sources */,
+				636619A32476B361008E573D /* CoreDataBatchUpdateOperation.swift in Sources */,
 				8D94662022146BF500B2197D /* NSPredicate.swift in Sources */,
 				CBF972BE1E5DEF2900F37801 /* CoreDataBatchImportOperation.swift in Sources */,
 				186D313922CB847F003A5A8F /* CollectionViewUpdatable.swift in Sources */,

--- a/PeakCoreData.xcodeproj/project.pbxproj
+++ b/PeakCoreData.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		636619A52476B36D008E573D /* CoreDataBatchDeleteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A42476B36D008E573D /* CoreDataBatchDeleteOperation.swift */; };
 		636619A62476B38F008E573D /* CoreDataBatchDeleteOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A42476B36D008E573D /* CoreDataBatchDeleteOperation.swift */; };
 		636619A72476B395008E573D /* CoreDataBatchUpdateOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 636619A22476B361008E573D /* CoreDataBatchUpdateOperation.swift */; };
+		636619A82476B9BA008E573D /* ManagedObjectCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346D9F124360C8400521E6C /* ManagedObjectCache.swift */; };
+		636619A92476B9C5008E573D /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346D9EF24360C4700521E6C /* Cache.swift */; };
 		8D05BE6D2051518B00DE93AC /* FetchedDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D05BE6C2051518B00DE93AC /* FetchedDataProvider.swift */; };
 		8D159AFE205C001A004D693A /* AnotherEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D159AFD205C001A004D693A /* AnotherEntity.swift */; };
 		8D159B00205C01EE004D693A /* ContextDidSaveNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D159AFF205C01EE004D693A /* ContextDidSaveNotification.swift */; };
@@ -743,11 +745,13 @@
 				186D313A22CB849E003A5A8F /* FetchedDataProvider.swift in Sources */,
 				186D312822CB651C003A5A8F /* ObjectDidChangeNotification.swift in Sources */,
 				186D313522CB669E003A5A8F /* UniqueIdentifiable.swift in Sources */,
+				636619A82476B9BA008E573D /* ManagedObjectCache.swift in Sources */,
 				186D312E22CB6521003A5A8F /* CoreDataToIntermediateOperation.swift in Sources */,
 				186D312D22CB6521003A5A8F /* CoreDataSingleImportOperation.swift in Sources */,
 				186D312B22CB6521003A5A8F /* CoreDataChangesetOperation.swift in Sources */,
 				186D312922CB6521003A5A8F /* Changeset.swift in Sources */,
 				186D312722CB651C003A5A8F /* ContextDidSaveNotification.swift in Sources */,
+				636619A92476B9C5008E573D /* Cache.swift in Sources */,
 				186D313222CB669E003A5A8F /* ManagedObjectType.swift in Sources */,
 				186D312C22CB6521003A5A8F /* CoreDataBatchImportOperation.swift in Sources */,
 				186D312622CB6519003A5A8F /* ManagedObjectObserver.swift in Sources */,

--- a/PeakCoreData/Core/Operations/CoreDataBatchDeleteOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataBatchDeleteOperation.swift
@@ -8,7 +8,8 @@
 
 import CoreData
 
-open class CoreDataBatchDeleteOperation<Entity: ManagedObjectType>: CoreDataOperation<Int> {
+/// Performs an `NSBatchDeleteRequest` and returns an array of deleted `NSManagedObjectID`s.
+open class CoreDataBatchDeleteOperation<Entity: ManagedObjectType>: CoreDataOperation<[NSManagedObjectID]> {
     
     private let predicate: NSPredicate?
     
@@ -27,7 +28,7 @@ open class CoreDataBatchDeleteOperation<Entity: ManagedObjectType>: CoreDataOper
             let objectIDArray = result.result as! [NSManagedObjectID]
             let changes = [NSDeletedObjectsKey: objectIDArray]
             NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
-            output = .success(objectIDArray.count)
+            output = .success(objectIDArray)
         } catch {
             output = .failure(error)
         }

--- a/PeakCoreData/Core/Operations/CoreDataBatchDeleteOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataBatchDeleteOperation.swift
@@ -1,0 +1,36 @@
+//
+//  CoreDataBatchDeleteOperation.swift
+//  PeakCoreData
+//
+//  Created by David Yates on 21/05/2020.
+//  Copyright © 2020 3Squared Ltd. All rights reserved.
+//
+
+import CoreData
+
+open class CoreDataBatchDeleteOperation<Entity: ManagedObjectType>: CoreDataOperation<Int> {
+    
+    private let predicate: NSPredicate?
+    
+    public init(predicate: NSPredicate? = nil, persistentContainer: NSPersistentContainer, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
+        self.predicate = predicate
+        super.init(persistentContainer: persistentContainer, mergePolicyType: mergePolicyType)
+    }
+    
+    open override func performWork(in context: NSManagedObjectContext) {
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: Entity.entityName)
+        request.predicate = predicate
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        deleteRequest.resultType = .resultTypeObjectIDs
+        do {
+            let result = try context.execute(deleteRequest) as! NSBatchDeleteResult
+            let objectIDArray = result.result as! [NSManagedObjectID]
+            let changes = [NSDeletedObjectsKey: objectIDArray]
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
+            output = .success(objectIDArray.count)
+        } catch {
+            output = .failure(error)
+        }
+        saveAndFinish()
+    }
+}

--- a/PeakCoreData/Core/Operations/CoreDataBatchImportOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataBatchImportOperation.swift
@@ -24,12 +24,12 @@ open class CoreDataBatchImportOperation<Intermediate>: CoreDataChangesetOperatio
             let importProgress = Progress(totalUnitCount: Int64(intermediates.count) * 2)
             progress.addChild(importProgress, withPendingUnitCount: progress.totalUnitCount)
 
-            ManagedObject.insertOrUpdate(intermediates: intermediates, in: context) { intermediate, managedObject in
+            ManagedObject.insertOrUpdate(intermediates: intermediates, in: context, with: cache) { intermediate, managedObject in
                 intermediate.updateProperties(on: managedObject)
                 importProgress.completedUnitCount += 1
             }
             
-            ManagedObject.insertOrUpdate(intermediates: intermediates, in: context) { intermediate, managedObject in
+            ManagedObject.insertOrUpdate(intermediates: intermediates, in: context, with: cache) { intermediate, managedObject in
                 intermediate.updateRelationships(on: managedObject, in: context)
                 importProgress.completedUnitCount += 1
             }

--- a/PeakCoreData/Core/Operations/CoreDataBatchUpdateOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataBatchUpdateOperation.swift
@@ -1,0 +1,38 @@
+//
+//  CoreDataBatchUpdateOperation.swift
+//  PeakCoreData
+//
+//  Created by David Yates on 21/05/2020.
+//  Copyright © 2020 3Squared Ltd. All rights reserved.
+//
+
+import CoreData
+
+class CoreDataBatchUpdateOperation<Entity: ManagedObjectType>: CoreDataOperation<[NSManagedObjectID]> {
+        
+    private let propertiesToUpdate: [AnyHashable: Any]
+    private let predicate: NSPredicate?
+    
+    init(propertiesToUpdate: [AnyHashable: Any], predicate: NSPredicate? = nil, persistentContainer: NSPersistentContainer, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
+        self.propertiesToUpdate = propertiesToUpdate
+        self.predicate = predicate
+        super.init(persistentContainer: persistentContainer, mergePolicyType: mergePolicyType)
+    }
+    
+    override func performWork(in context: NSManagedObjectContext) {
+        let request = NSBatchUpdateRequest(entityName: Entity.entityName)
+        request.predicate = predicate
+        request.propertiesToUpdate = propertiesToUpdate
+        request.resultType = .updatedObjectIDsResultType
+        do {
+            let result = try context.execute(request) as! NSBatchUpdateResult
+            let objectIDArray = result.result as! [NSManagedObjectID]
+            let changes = [NSUpdatedObjectsKey: objectIDArray]
+            NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [context])
+            output = .success(objectIDArray)
+        } catch {
+            output = .failure(error)
+        }
+        saveAndFinish()
+    }
+}

--- a/PeakCoreData/Core/Operations/CoreDataBatchUpdateOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataBatchUpdateOperation.swift
@@ -8,6 +8,7 @@
 
 import CoreData
 
+/// Performs an `NSBatchUpdateRequest` and returns an array of updated `NSManagedObjectID`s.
 class CoreDataBatchUpdateOperation<Entity: ManagedObjectType>: CoreDataOperation<[NSManagedObjectID]> {
         
     private let propertiesToUpdate: [AnyHashable: Any]

--- a/PeakCoreData/Core/Operations/CoreDataChangesetOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataChangesetOperation.swift
@@ -13,6 +13,7 @@ open class CoreDataChangesetOperation: CoreDataOperation<Changeset> {
     
     open override func saveAndFinish() {
         guard !isCancelled else { return finish() }
+        
         saveOperationContext()
         output = Result { return Changeset(inserted: inserted, updated: updated) }
         finish()

--- a/PeakCoreData/Core/Operations/CoreDataOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataOperation.swift
@@ -10,19 +10,22 @@ import CoreData
 import PeakOperation
 
 open class CoreDataOperation<Output>: ConcurrentOperation, ProducesResult {
-    private let persistentContainer: NSPersistentContainer
-    private let mergePolicyType: NSMergePolicyType
-    private var operationContext: NSManagedObjectContext!
+        
+    public var output: Result<Output, Error> = Result { throw ResultError.noResult }
     
     var inserted: Set<NSManagedObjectID> = []
     var updated: Set<NSManagedObjectID> = []
     var deleted: Set<NSManagedObjectID> = []
-        
-    public var output: Result<Output, Error> = Result { throw ResultError.noResult }
+    var cache: ManagedObjectCache?
+    
+    private let persistentContainer: NSPersistentContainer
+    private let mergePolicyType: NSMergePolicyType
+    private var operationContext: NSManagedObjectContext!
 
-    public init(with persistentContainer: NSPersistentContainer, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
+    public init(persistentContainer: NSPersistentContainer, cache: ManagedObjectCache? = nil, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
         self.persistentContainer = persistentContainer
         self.mergePolicyType = mergePolicyType
+        self.cache = cache
     }
     
     // MARK: - ConcurrentOperation Overrides

--- a/PeakCoreData/Core/Operations/CoreDataSingleImportOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataSingleImportOperation.swift
@@ -20,7 +20,7 @@ open class CoreDataSingleImportOperation<Intermediate>: CoreDataChangesetOperati
     open override func performWork(in context: NSManagedObjectContext) {
         do {
             let intermediate = try input.get()
-            let managedObject = ManagedObject.fetchOrInsertObject(with: intermediate.uniqueIDValue, in: context)
+            let managedObject = ManagedObject.fetchOrInsertObject(with: intermediate.uniqueIDValue, in: context, with: cache)
             intermediate.updateProperties(on: managedObject)
             intermediate.updateRelationships(on: managedObject, in: context)
             saveAndFinish()

--- a/PeakCoreData/Core/Operations/CoreDataToIntermediateOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataToIntermediateOperation.swift
@@ -23,12 +23,12 @@ open class CoreDataToIntermediateOperation<Intermediate>: CoreDataOperation<[Int
     }
     
     open override func performWork(in context: NSManagedObjectContext) {
-        let objects = ManagedObject.fetch(in: context) { (request) in
-            request.predicate = self.predicate
-        }
+        let objects = ManagedObject.fetch(in: context) { $0.predicate = self.predicate }
+        
         output = Result {
             try objects.map(Intermediate.init)
         }
+        
         finish()
     }
 }

--- a/PeakCoreData/Core/Operations/CoreDataToIntermediateOperation.swift
+++ b/PeakCoreData/Core/Operations/CoreDataToIntermediateOperation.swift
@@ -17,9 +17,9 @@ open class CoreDataToIntermediateOperation<Intermediate>: CoreDataOperation<[Int
     
     private let predicate: NSPredicate?
     
-    public init(with persistentContainer: NSPersistentContainer, matching predicate: NSPredicate? = nil) {
+    public init(predicate: NSPredicate? = nil, persistentContainer: NSPersistentContainer) {
         self.predicate = predicate
-        super.init(with: persistentContainer)
+        super.init(persistentContainer: persistentContainer)
     }
     
     open override func performWork(in context: NSManagedObjectContext) {

--- a/Unit Tests/Core/OperationTests.swift
+++ b/Unit Tests/Core/OperationTests.swift
@@ -72,7 +72,7 @@ class OperationTests: CoreDataTests, NSFetchedResultsControllerDelegate {
             try! viewContext.save()
             
             // Create import operation with intermediates as input
-            let operation = CoreDataSingleImportOperation<TestEntityJSON>(with: persistentContainer)
+            let operation = CoreDataSingleImportOperation<TestEntityJSON>(persistentContainer: persistentContainer)
             operation.input = Result { input.first! }
             
             if let previousOperation = previousOperation {
@@ -108,7 +108,7 @@ class OperationTests: CoreDataTests, NSFetchedResultsControllerDelegate {
             
             
             // Create import operation with intermediates as input
-            let operation = CoreDataBatchImportOperation<TestEntityJSON>(with: persistentContainer)
+            let operation = CoreDataBatchImportOperation<TestEntityJSON>(persistentContainer: persistentContainer)
             operation.input = Result { input }
             
             if let previousOperation = previousOperation {
@@ -137,7 +137,7 @@ class OperationTests: CoreDataTests, NSFetchedResultsControllerDelegate {
         try! persistentContainer.viewContext.save()
         
         // Create import operation with intermediates as input
-        let operation = CoreDataBatchImportOperation<TestEntityJSON>(with: persistentContainer)
+        let operation = CoreDataBatchImportOperation<TestEntityJSON>(persistentContainer: persistentContainer)
         operation.input = Result { input }
         
         operation.addResultBlock { result in
@@ -182,7 +182,7 @@ class OperationTests: CoreDataTests, NSFetchedResultsControllerDelegate {
         try! frc.performFetch()
         
         // Create import operation with intermediates as input
-        let operation = CoreDataBatchImportOperation<TestEntityJSON>(with: persistentContainer)
+        let operation = CoreDataBatchImportOperation<TestEntityJSON>(persistentContainer: persistentContainer)
         operation.input = Result { intermediateItems }
         
         operationQueue.addOperation(operation)
@@ -211,7 +211,7 @@ class OperationTests: CoreDataTests, NSFetchedResultsControllerDelegate {
         let insertedTitles = inserted.compactMap({ $0.title }).sorted(by: { $0 < $1 })
         try! viewContext.save()
         
-        let operation = CoreDataToIntermediateOperation<TestEntityJSON>(with: persistentContainer)
+        let operation = CoreDataToIntermediateOperation<TestEntityJSON>(persistentContainer: persistentContainer)
         operation.addResultBlock { (result) in
             let outcome = try! result.get()
             XCTAssertEqual(outcome.count, insertCount)
@@ -238,7 +238,7 @@ class OperationTests: CoreDataTests, NSFetchedResultsControllerDelegate {
         try! persistentContainer.viewContext.save()
         
         let predicate = NSPredicate(equalTo: true, keyPath: #keyPath(TestEntity.edited))
-        let fetchAndEncodeOperation = CoreDataToIntermediateOperation<TestEntityJSON>(with: persistentContainer, matching: predicate)
+        let fetchAndEncodeOperation = CoreDataToIntermediateOperation<TestEntityJSON>(predicate: predicate, persistentContainer: persistentContainer)
         fetchAndEncodeOperation.addResultBlock { (result) in
             let outcome = try! result.get()
             XCTAssertEqual(outcome.count, insertCount)
@@ -284,7 +284,7 @@ class AddOneOperation: CoreDataOperation<Void> {
 
     init(uniqueKeyValue: String, persistentContainer: NSPersistentContainer) {
         self.uniqueKeyValue = uniqueKeyValue
-        super.init(with: persistentContainer)
+        super.init(persistentContainer: persistentContainer)
     }
     
     override func performWork(in context: NSManagedObjectContext) {
@@ -302,7 +302,7 @@ class InsertThenDeleteOperation: CoreDataChangesetOperation {
     init(insertCount: Int, deleteCount: Int, persistentContainer: NSPersistentContainer) {
         self.insertCount = insertCount
         self.deleteCount = deleteCount
-        super.init(with: persistentContainer)
+        super.init(persistentContainer: persistentContainer)
     }
     
     override func performWork(in context: NSManagedObjectContext) {

--- a/Unit Tests/Core/ProgressTests.swift
+++ b/Unit Tests/Core/ProgressTests.swift
@@ -27,7 +27,7 @@ class ProgressTests: CoreDataTests {
         try! viewContext.save()
         
         // Create import operation with intermediates as input
-        let operation = CoreDataBatchImportOperation<TestEntityJSON>(with: persistentContainer)
+        let operation = CoreDataBatchImportOperation<TestEntityJSON>(persistentContainer: persistentContainer)
         operation.input = Result { input }
         
         let progress = operation.chainProgress()


### PR DESCRIPTION
Adds batch update and batch delete operations.
Allows a ManagedObjectCache to be passed in to a Batch Import Operation
Fixes parameter names in operation initialisers to better match Swift guidelines.
