### PR TITLE
Parameter fixes

### DIFF
--- a/Example/PeakCoreDataExample/PeakCoreDataExample/Model/Event.swift
+++ b/Example/PeakCoreDataExample/PeakCoreDataExample/Model/Event.swift
@@ -56,7 +56,7 @@ extension EventJSON: ManagedObjectUpdatable {
     
     public static var updateRelationships: UpdateRelationshipsBlock? = { intermediate, managedObject, context, cache in
         
-        Person.insertOrUpdate(intermediates: intermediate.attendees, in: context) { (json, person) in
+        Person.insertOrUpdate(intermediates: intermediate.attendees, context: context) { (json, person) in
             PersonJSON.updateProperties?(json, person)
             managedObject.addToAttendees(person)
         }

--- a/Example/PeakCoreDataExample/PeakCoreDataExample/View Controllers/EventDetailViewController.swift
+++ b/Example/PeakCoreDataExample/PeakCoreDataExample/View Controllers/EventDetailViewController.swift
@@ -33,12 +33,12 @@ class EventDetailViewController: UITableViewController, PersistentContainerSetta
         
         eventObserver = ManagedObjectObserver(managedObject: event)
         eventObserver.startObserving() { [weak self] obj, changeType in
-            guard let strongSelf = self else { return }
+            guard let self = self else { return }
             switch changeType {
             case .initialised, .refreshed, .updated:
-                strongSelf.updateLabels()
+                self.updateLabels()
             case .deleted:
-                strongSelf.navigationController?.popToRootViewController(animated: true)
+                self.navigationController?.popToRootViewController(animated: true)
             }
         }
         setupTableView()

--- a/Example/PeakCoreDataExample/PeakCoreDataExample/View Controllers/EventsTableViewController.swift
+++ b/Example/PeakCoreDataExample/PeakCoreDataExample/View Controllers/EventsTableViewController.swift
@@ -44,8 +44,8 @@ class EventsTableViewController: UITableViewController, PersistentContainerSetta
         
         countObserver = CountObserver<Event>(predicate: nil, context: viewContext)
         countObserver.startObserving() { [weak self] count in
-            guard let strongSelf = self else { return }
-            strongSelf.countLabel.text = String(count)
+            guard let self = self else { return }
+            self.countLabel.text = String(count)
         }
         setupTableView()
     }

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ override func viewDidLoad() {
     
     eventObserver = ManagedObjectObserver(managedObject: event)
     eventObserver.startObserving() { [weak self] obj, changeType in
-        guard let strongSelf = self else { return }
+        guard let self = self else { return }
         switch changeType {
         case .initialised, .refreshed, .updated:
-            strongSelf.updateView()
+            self.updateView()
         case .deleted:
-            strongSelf.navigationController?.popToRootViewController(animated: true)
+            self.navigationController?.popToRootViewController(animated: true)
         }
     }
 }
@@ -41,8 +41,8 @@ override func viewDidLoad() {
     let predicate = NSPredicate(format: "%K == false", argumentArray: [#KeyPath(Event.isHidden)])
     countObserver = CountObserver<Event>(predicate: predicate, context: viewContext)
     countObserver.startObserving() { [weak self] count in
-        guard let strongSelf = self else { return }
-        strongSelf.countLabel.text = String(count)
+        guard let self = self else { return }
+        self.countLabel.text = String(count)
     }
 }
 ```

--- a/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
@@ -21,7 +21,7 @@ extension CollectionViewUpdatable {
                         collectionView: UICollectionView,
                         completion: ((Bool) -> Void)? = nil) {
         let batchUpdates: () -> Void = { [weak self] in
-            guard let strongSelf = self else { return }
+            guard let self = self else { return }
             
             updates.forEach { (update) in
                 switch update {
@@ -29,7 +29,7 @@ extension CollectionViewUpdatable {
                     collectionView.insertItems(at: [indexPath])
                 case .update(let indexPath, let object):
                     guard let cell = collectionView.cellForItem(at: indexPath) as? Cell else { return }
-                    strongSelf.configure(cell, with: object)
+                    self.configure(cell, with: object)
                 case .move(let indexPath, let newIndexPath):
                     collectionView.moveItem(at: indexPath, to: newIndexPath)
                 case .delete(let indexPath):

--- a/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
@@ -20,7 +20,7 @@ extension CollectionViewUpdatable {
     public func process(updates: [FetchedUpdate<Object>],
                         collectionView: UICollectionView,
                         completion: ((Bool) -> Void)? = nil) {
-        let batchUpdates: () -> Void = { [weak self] in
+        let batchUpdates = { [weak self] in
             guard let self = self else { return }
             
             updates.forEach { (update) in

--- a/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
@@ -17,7 +17,9 @@ public protocol CollectionViewUpdatable: AnyObject {
 
 extension CollectionViewUpdatable {
     
-    public func process(updates: [FetchedUpdate<Object>], for collectionView: UICollectionView, completion: ((Bool) -> Void)? = nil) {
+    public func process(updates: [FetchedUpdate<Object>],
+                        for collectionView: UICollectionView,
+                        completion: ((Bool) -> Void)? = nil) {
         let batchUpdates: () -> Void = { [weak self] in
             guard let strongSelf = self else { return }
             

--- a/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/CollectionViewUpdatable.swift
@@ -18,7 +18,7 @@ public protocol CollectionViewUpdatable: AnyObject {
 extension CollectionViewUpdatable {
     
     public func process(updates: [FetchedUpdate<Object>],
-                        for collectionView: UICollectionView,
+                        collectionView: UICollectionView,
                         completion: ((Bool) -> Void)? = nil) {
         let batchUpdates: () -> Void = { [weak self] in
             guard let strongSelf = self else { return }

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedCollection.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedCollection.swift
@@ -22,27 +22,27 @@ public class FetchedCollection<T: NSManagedObject>: NSObject {
     private let dataProvider: FetchedDataProvider<FetchedCollection>
     
     public var sections: [NSFetchedResultsSectionInfo] {
-        return dataProvider.sections
+        dataProvider.sections
     }
     
     public func object(at indexPath: IndexPath) -> T {
-        return dataProvider.object(at: indexPath)
+        dataProvider.object(at: indexPath)
     }
     
     public func index(of object: T) -> IndexPath? {
-        return dataProvider.indexPath(forObject: object)
+        dataProvider.indexPath(forObject: object)
     }
     
     public var count: Int {
-        return dataProvider.fetchedObjectsCount
+        dataProvider.fetchedObjectsCount
     }
     
     public func snapshot() -> [T] {
-        return dataProvider.fetchedObjects
+        dataProvider.fetchedObjects
     }
     
     public var isEmpty: Bool {
-        return dataProvider.fetchedObjectsCount == 0
+        dataProvider.fetchedObjectsCount == 0
     }
     
     /// Create a new FetchedCollection.
@@ -52,7 +52,10 @@ public class FetchedCollection<T: NSManagedObject>: NSObject {
     ///   - context: The context that will hold the fetched objects.
     ///   - sectionNameKeyPath: A keypath on resulting objects that returns the section name. This will be used to pre-compute the section information.
     ///   - cacheName: Section info is cached persistently to a private file under this name. Cached sections are checked to see if the time stamp matches the store, but not if you have illegally mutated the readonly fetch request, predicate, or sort descriptor.
-    public init(fetchRequest: NSFetchRequest<T>, context: NSManagedObjectContext, sectionNameKeyPath: String? = nil, cacheName: String? = nil) {
+    public init(fetchRequest: NSFetchRequest<T>,
+                context: NSManagedObjectContext,
+                sectionNameKeyPath: String? = nil,
+                cacheName: String? = nil) {
         let frc = NSFetchedResultsController(fetchRequest: fetchRequest,
                                              managedObjectContext: context,
                                              sectionNameKeyPath: sectionNameKeyPath,
@@ -72,15 +75,15 @@ public class FetchedCollection<T: NSManagedObject>: NSObject {
 extension FetchedCollection {
     
     public subscript (position: IndexPath) -> T {
-        return dataProvider.object(at: position)
+        dataProvider.object(at: position)
     }
     
     public subscript (position: (item: Int, section: Int)) -> T {
-        return dataProvider.object(at: IndexPath(item: position.item, section: position.section))
+        dataProvider.object(at: IndexPath(item: position.item, section: position.section))
     }
     
     public subscript (item: Int, section: Int) -> T {
-        return dataProvider.object(at: IndexPath(item: item, section: section))
+        dataProvider.object(at: IndexPath(item: item, section: section))
     }
 }
 

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
@@ -183,9 +183,9 @@ extension FetchedCollectionViewDataSource: FetchedDataProviderDelegate {
         }
         
         delegate.process(updates: updates, collectionView: collectionView) { [weak self] _ in
-            guard let strongSelf = self else { return }
-            strongSelf.showEmptyViewIfNeeded()
-            strongSelf.onDidChangeContent?()
+            guard let self = self else { return }
+            self.showEmptyViewIfNeeded()
+            self.onDidChangeContent?()
         }
     }
 }

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
@@ -45,30 +45,32 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     public var onDidChangeContent: (() -> Void)?
     
     public var cacheName: String? {
-        return dataProvider.cacheName
+        dataProvider.cacheName
     }
     
     public var fetchedObjectsCount: Int {
-        return dataProvider.fetchedObjectsCount
+        dataProvider.fetchedObjectsCount
     }
     
     public var isEmpty: Bool {
-        return dataProvider.isEmpty
+        dataProvider.isEmpty
     }
     
     public var numberOfSections: Int {
-        return dataProvider.numberOfSections
+        dataProvider.numberOfSections
     }
     
     public var sectionIndexTitles: [String] {
-        return dataProvider.sectionIndexTitles
+        dataProvider.sectionIndexTitles
     }
     
     public var sectionNameKeyPath: String? {
-        return dataProvider.sectionNameKeyPath
+        dataProvider.sectionNameKeyPath
     }
     
-    public required init(collectionView: UICollectionView, fetchedResultsController: NSFetchedResultsController<Object>, delegate: Delegate) {
+    public required init(collectionView: UICollectionView,
+                         fetchedResultsController: NSFetchedResultsController<Object>,
+                         delegate: Delegate) {
         self.collectionView = collectionView
         self.delegate = delegate
         self.dataProvider = FetchedDataProvider(fetchedResultsController: fetchedResultsController)
@@ -78,19 +80,19 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     }
     
     public func indexPath(forObject object: Object) -> IndexPath? {
-        return dataProvider.indexPath(forObject: object)
+        dataProvider.indexPath(forObject: object)
     }
     
     public func name(in section: Int) -> String? {
-        return dataProvider.name(in: section)
+        dataProvider.name(in: section)
     }
     
     public func numberOfItems(in section: Int) -> Int {
-        return dataProvider.numberOfItems(in: section)
+        dataProvider.numberOfItems(in: section)
     }
     
     public func object(at indexPath: IndexPath) -> Object {
-        return dataProvider.object(at: indexPath)
+        dataProvider.object(at: indexPath)
     }
     
     public func performFetch() {
@@ -98,11 +100,11 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     }
     
     public func section(forSectionIndexTitle title: String, at index: Int) -> Int {
-        return dataProvider.section(forSectionIndexTitle: title, at: index)
+        dataProvider.section(forSectionIndexTitle: title, at: index)
     }
     
     public func sectionInfo(forSection section: Int) -> NSFetchedResultsSectionInfo {
-        return dataProvider.sectionInfo(forSection: section)
+        dataProvider.sectionInfo(forSection: section)
     }
     
     public func reconfigureFetchRequest(_ configure: (NSFetchRequest<Object>) -> Void) {
@@ -120,11 +122,11 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     // MARK: UICollectionViewDataSource
     
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return numberOfSections
+        numberOfSections
     }
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return numberOfItems(in: section)
+        numberOfItems(in: section)
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -162,7 +164,7 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     }
     
     public func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
-        return delegate.canMoveItem(at: indexPath)
+        delegate.canMoveItem(at: indexPath)
     }
     
     public func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
@@ -182,7 +182,7 @@ extension FetchedCollectionViewDataSource: FetchedDataProviderDelegate {
             return
         }
         
-        delegate.process(updates: updates, for: collectionView) { [weak self] _ in
+        delegate.process(updates: updates, collectionView: collectionView) { [weak self] _ in
             guard let strongSelf = self else { return }
             strongSelf.showEmptyViewIfNeeded()
             strongSelf.onDidChangeContent?()

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedDataProvider.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedDataProvider.swift
@@ -49,27 +49,27 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     }
     
     var fetchedObjects: [Object] {
-        return fetchedResultsController.fetchedObjects ?? []
+        fetchedResultsController.fetchedObjects ?? []
     }
     
     var isEmpty: Bool {
-        return fetchedObjectsCount == 0
+        fetchedObjectsCount == 0
     }
     
     var sections: [NSFetchedResultsSectionInfo] {
-        return fetchedResultsController.sections ?? []
+        fetchedResultsController.sections ?? []
     }
 
     var numberOfSections: Int {
-        return sections.count
+        sections.count
     }
     
     var sectionIndexTitles: [String] {
-        return fetchedResultsController.sectionIndexTitles
+        fetchedResultsController.sectionIndexTitles
     }
     
     var sectionNameKeyPath: String? {
-        return fetchedResultsController.sectionNameKeyPath
+        fetchedResultsController.sectionNameKeyPath
     }
     
     private let fetchedResultsController: NSFetchedResultsController<Object>
@@ -91,7 +91,7 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     }
     
     func indexPath(forObject object: Object) -> IndexPath? {
-        return fetchedResultsController.indexPath(forObject: object)
+        fetchedResultsController.indexPath(forObject: object)
     }
     
     func name(in section: Int) -> String? {
@@ -105,15 +105,15 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     }
     
     func object(at indexPath: IndexPath) -> Object {
-        return fetchedResultsController.object(at: indexPath)
+        fetchedResultsController.object(at: indexPath)
     }
     
     func section(forSectionIndexTitle title: String, at index: Int) -> Int {
-        return fetchedResultsController.section(forSectionIndexTitle: title, at: index)
+        fetchedResultsController.section(forSectionIndexTitle: title, at: index)
     }
     
     func sectionInfo(forSection section: Int) -> NSFetchedResultsSectionInfo {
-        return fetchedResultsController.sections![section] as NSFetchedResultsSectionInfo
+        fetchedResultsController.sections![section] as NSFetchedResultsSectionInfo
     }
     
     func reconfigureFetchRequest(_ configure: (NSFetchRequest<Object>) -> Void) {

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
@@ -181,9 +181,9 @@ extension FetchedTableViewDataSource: FetchedDataProviderDelegate {
         }
         
         delegate.process(updates: updates, tableView: tableView, animation: delegate.rowAnimation) { [weak self] _ in
-            guard let strongSelf = self else { return }
-            strongSelf.showEmptyViewIfNeeded()
-            strongSelf.onDidChangeContent?()
+            guard let self = self else { return }
+            self.showEmptyViewIfNeeded()
+            self.onDidChangeContent?()
         }
     }
 }

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
@@ -44,30 +44,32 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     public var onDidChangeContent: (() -> Void)?
     
     public var cacheName: String? {
-        return dataProvider.cacheName
+        dataProvider.cacheName
     }
     
     public var fetchedObjectsCount: Int {
-        return dataProvider.fetchedObjectsCount
+        dataProvider.fetchedObjectsCount
     }
     
     public var isEmpty: Bool {
-        return dataProvider.isEmpty
+        dataProvider.isEmpty
     }
     
     public var numberOfSections: Int {
-        return dataProvider.numberOfSections
+        dataProvider.numberOfSections
     }
     
     public var sectionIndexTitles: [String] {
-        return dataProvider.sectionIndexTitles
+        dataProvider.sectionIndexTitles
     }
     
     public var sectionNameKeyPath: String? {
-        return dataProvider.sectionNameKeyPath
+        dataProvider.sectionNameKeyPath
     }
     
-    public required init(tableView: UITableView, fetchedResultsController: NSFetchedResultsController<Object>, delegate: Delegate) {
+    public required init(tableView: UITableView,
+                         fetchedResultsController: NSFetchedResultsController<Object>,
+                         delegate: Delegate) {
         self.tableView = tableView
         self.delegate = delegate
         self.dataProvider = FetchedDataProvider(fetchedResultsController: fetchedResultsController)
@@ -77,19 +79,19 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func indexPath(forObject object: Object) -> IndexPath? {
-        return dataProvider.indexPath(forObject: object)
+        dataProvider.indexPath(forObject: object)
     }
     
     public func name(in section: Int) -> String? {
-        return dataProvider.name(in: section)
+        dataProvider.name(in: section)
     }
     
     public func numberOfItems(in section: Int) -> Int {
-        return dataProvider.numberOfItems(in: section)
+        dataProvider.numberOfItems(in: section)
     }
     
     public func object(at indexPath: IndexPath) -> Object {
-        return dataProvider.object(at: indexPath)
+        dataProvider.object(at: indexPath)
     }
     
     public func performFetch() {
@@ -97,11 +99,11 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func section(forSectionIndexTitle title: String, at index: Int) -> Int {
-        return dataProvider.section(forSectionIndexTitle: title, at: index)
+        dataProvider.section(forSectionIndexTitle: title, at: index)
     }
     
     public func sectionInfo(forSection section: Int) -> NSFetchedResultsSectionInfo {
-        return dataProvider.sectionInfo(forSection: section)
+        dataProvider.sectionInfo(forSection: section)
     }
     
     public func reconfigureFetchRequest(_ configure: (NSFetchRequest<Object>) -> Void) {
@@ -119,11 +121,11 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     // MARK: UITableViewDataSource
     
     public func numberOfSections(in tableView: UITableView) -> Int {
-        return numberOfSections
+        numberOfSections
     }
     
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return numberOfItems(in: section)
+        numberOfItems(in: section)
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -136,15 +138,15 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return delegate.titleForHeader(in: section)
+        delegate.titleForHeader(in: section)
     }
     
     public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return delegate.titleForFooter(in: section)
+        delegate.titleForFooter(in: section)
     }
     
     public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return delegate.canEditRow(at: indexPath)
+        delegate.canEditRow(at: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
@@ -152,7 +154,7 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return delegate.canMoveRow(at: indexPath)
+        delegate.canMoveRow(at: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
@@ -160,11 +162,11 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
-        return showSectionIndexTitles ? sectionIndexTitles : nil
+        showSectionIndexTitles ? sectionIndexTitles : nil
     }
     
     public func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
-        return section(forSectionIndexTitle: title, at: index)
+        section(forSectionIndexTitle: title, at: index)
     }
 }
 

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
@@ -180,7 +180,7 @@ extension FetchedTableViewDataSource: FetchedDataProviderDelegate {
             return
         }
         
-        delegate.process(updates: updates, for: tableView, with: delegate.rowAnimation) { [weak self] _ in
+        delegate.process(updates: updates, tableView: tableView, animation: delegate.rowAnimation) { [weak self] _ in
             guard let strongSelf = self else { return }
             strongSelf.showEmptyViewIfNeeded()
             strongSelf.onDidChangeContent?()

--- a/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
@@ -21,7 +21,7 @@ extension TableViewUpdatable {
                         tableView: UITableView,
                         animation: UITableView.RowAnimation = .automatic,
                         completion: ((Bool) -> Void)? = nil) {
-        let batchUpdates: () -> Void = { [weak self] in
+        let batchUpdates = { [weak self] in
             guard let self = self else { return }
             
             updates.forEach { (update) in

--- a/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
@@ -17,7 +17,10 @@ public protocol TableViewUpdatable: AnyObject {
 
 extension TableViewUpdatable {
     
-    public func process(updates: [FetchedUpdate<Object>], for tableView: UITableView, with animation: UITableView.RowAnimation = .automatic, completion: ((Bool) -> Void)? = nil) {
+    public func process(updates: [FetchedUpdate<Object>],
+                        for tableView: UITableView,
+                        with animation: UITableView.RowAnimation = .automatic,
+                        completion: ((Bool) -> Void)? = nil) {
         let batchUpdates: () -> Void = { [weak self] in
             guard let strongSelf = self else { return }
             

--- a/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
@@ -18,8 +18,8 @@ public protocol TableViewUpdatable: AnyObject {
 extension TableViewUpdatable {
     
     public func process(updates: [FetchedUpdate<Object>],
-                        for tableView: UITableView,
-                        with animation: UITableView.RowAnimation = .automatic,
+                        tableView: UITableView,
+                        animation: UITableView.RowAnimation = .automatic,
                         completion: ((Bool) -> Void)? = nil) {
         let batchUpdates: () -> Void = { [weak self] in
             guard let strongSelf = self else { return }

--- a/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
@@ -22,7 +22,7 @@ extension TableViewUpdatable {
                         animation: UITableView.RowAnimation = .automatic,
                         completion: ((Bool) -> Void)? = nil) {
         let batchUpdates: () -> Void = { [weak self] in
-            guard let strongSelf = self else { return }
+            guard let self = self else { return }
             
             updates.forEach { (update) in
                 switch update {
@@ -30,7 +30,7 @@ extension TableViewUpdatable {
                     tableView.insertRows(at: [indexPath], with: animation)
                 case .update(let indexPath, let object):
                     guard let cell = tableView.cellForRow(at: indexPath) as? Cell else { return }
-                    strongSelf.configure(cell, with: object)
+                    self.configure(cell, with: object)
                 case .move(let indexPath, let newIndexPath):
                     tableView.moveRow(at: indexPath, to: newIndexPath)
                 case .delete(let indexPath):

--- a/Sources/PeakCoreData/Helpers/NSEntityDescription.swift
+++ b/Sources/PeakCoreData/Helpers/NSEntityDescription.swift
@@ -20,8 +20,8 @@ extension NSEntityDescription {
      - parameter mergeContexts: Optional contexts into which changes can be merged.
      */
     public func batchDelete(in context: NSManagedObjectContext,
-                            matching predicate: NSPredicate? = nil,
-                            mergingInto mergeContexts: [NSManagedObjectContext]? = nil) {
+                            predicate: NSPredicate? = nil,
+                            mergeContexts: [NSManagedObjectContext]? = nil) {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: self.name!)
         request.predicate = predicate
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)

--- a/Sources/PeakCoreData/Helpers/NSEntityDescription.swift
+++ b/Sources/PeakCoreData/Helpers/NSEntityDescription.swift
@@ -20,7 +20,7 @@ extension NSEntityDescription {
      - parameter mergeContexts: Optional contexts into which changes can be merged.
      */
     public func batchDelete(in context: NSManagedObjectContext,
-                            predicate: NSPredicate? = nil,
+                            matching predicate: NSPredicate? = nil,
                             mergeContexts: [NSManagedObjectContext]? = nil) {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: self.name!)
         request.predicate = predicate

--- a/Sources/PeakCoreData/Helpers/NSEntityDescription.swift
+++ b/Sources/PeakCoreData/Helpers/NSEntityDescription.swift
@@ -22,7 +22,9 @@ extension NSEntityDescription {
     public func batchDelete(in context: NSManagedObjectContext,
                             matching predicate: NSPredicate? = nil,
                             mergeContexts: [NSManagedObjectContext]? = nil) {
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: self.name!)
+        guard let entityName = name else { return }
+        
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
         request.predicate = predicate
         let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
         deleteRequest.resultType = .resultTypeObjectIDs

--- a/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
+++ b/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
@@ -51,7 +51,7 @@ extension NSManagedObjectContext {
      `mergeChanges(fromRemoteContextSave:into:)` function.
      
      - This method cannot be unit tested because it is incompatible with `NSInMemoryStoreType`.
-     - This is a convenience function for calling `batchDelete(in:predicate:mergeContexts:)` on `NSEntityDescription`
+     - This is a convenience function for calling `batchDelete(in:matching:mergeContexts:)` on `NSEntityDescription`
      across all entities in the data model.
      
      - parameter context:       The context to use.

--- a/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
+++ b/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
@@ -10,6 +10,16 @@ import CoreData
 
 extension NSManagedObjectContext {
     
+    public func insert<T: ManagedObjectType>() -> T {
+        guard let obj = NSEntityDescription.insertNewObject(forEntityName: T.entityName, into: self) as? T else {
+            fatalError("Tried to insert wrong object type")
+        }
+        return obj
+    }
+}
+
+extension NSManagedObjectContext {
+    
     typealias VoidBlock = () -> Void
     typealias VoidBlockBlock = (VoidBlock) -> Void
     

--- a/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
+++ b/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
@@ -51,17 +51,15 @@ extension NSManagedObjectContext {
      `mergeChanges(fromRemoteContextSave:into:)` function.
      
      - This method cannot be unit tested because it is incompatible with `NSInMemoryStoreType`.
-     - This is a convenience function for calling `batchDelete(in:matching:)` on `NSEntityDescription`
+     - This is a convenience function for calling `batchDelete(in:predicate:mergeContexts:)` on `NSEntityDescription`
      across all entities in the data model.
      
      - parameter context:       The context to use.
      - parameter mergeContexts: Optional contexts into which changes can be merged.
      */
     public func batchDeleteAllEntities(mergingInto mergeContexts: [NSManagedObjectContext]? = nil) {
-        if let entities = persistentStoreCoordinator?.managedObjectModel.entities {
-            for entity in entities {
-                entity.batchDelete(in: self, mergingInto: mergeContexts)
-            }
+        persistentStoreCoordinator?.managedObjectModel.entities.forEach {
+            $0.batchDelete(in: self, mergeContexts: mergeContexts)
         }
     }
 }

--- a/Sources/PeakCoreData/Observers/CountObserver.swift
+++ b/Sources/PeakCoreData/Observers/CountObserver.swift
@@ -18,7 +18,7 @@ public class CountObserver<T>: NSObject where T: ManagedObjectType {
     public var count: Int {
         var count: Int = 0
         context.performAndWait {
-            count = T.count(in: context, matching: predicate)
+            count = T.count(in: context, predicate: predicate)
         }
         return count
     }

--- a/Sources/PeakCoreData/Observers/CountObserver.swift
+++ b/Sources/PeakCoreData/Observers/CountObserver.swift
@@ -23,7 +23,6 @@ public class CountObserver<T>: NSObject where T: ManagedObjectType {
         return count
     }
     
-
     private let context: NSManagedObjectContext
     private let predicate: NSPredicate?
     

--- a/Sources/PeakCoreData/Observers/CountObserver.swift
+++ b/Sources/PeakCoreData/Observers/CountObserver.swift
@@ -52,11 +52,11 @@ public class CountObserver<T>: NSObject where T: ManagedObjectType {
         }
         
         NotificationCenter.default.addObserver(forName: NSNotification.Name.NSManagedObjectContextObjectsDidChange, object: nil, queue: nil) { [weak self] (note) in
-            guard let strongSelf = self else { return }
-            guard strongSelf.enabled else { return }
+            guard let self = self else { return }
+            guard self.enabled else { return }
             let notification = ObjectsDidChangeNotification(notification: note)
-            guard notification.managedObjectContext == strongSelf.context else { return }
-            strongSelf.contextDidChange(force: false)
+            guard notification.managedObjectContext == self.context else { return }
+            self.contextDidChange(force: false)
         }
         contextDidChange(force: true)
         notifierRunning = true
@@ -67,8 +67,8 @@ public class CountObserver<T>: NSObject where T: ManagedObjectType {
         guard force || newCount != previousCount else { return }
         
         DispatchQueue.main.async { [weak self] in
-            guard let strongSelf = self else { return }
-            strongSelf.onChange?(newCount)
+            guard let self = self else { return }
+            self.onChange?(newCount)
         }
         previousCount = newCount
     }

--- a/Sources/PeakCoreData/Observers/CountObserver.swift
+++ b/Sources/PeakCoreData/Observers/CountObserver.swift
@@ -18,7 +18,7 @@ public class CountObserver<T>: NSObject where T: ManagedObjectType {
     public var count: Int {
         var count: Int = 0
         context.performAndWait {
-            count = T.count(in: context, predicate: predicate)
+            count = T.count(in: context, matching: predicate)
         }
         return count
     }

--- a/Sources/PeakCoreData/Observers/ManagedObjectObserver.swift
+++ b/Sources/PeakCoreData/Observers/ManagedObjectObserver.swift
@@ -71,13 +71,13 @@ open class ManagedObjectObserver<T>: NSObject where T: ManagedObjectType {
         }
         
         NotificationCenter.default.addObserver(forName: NSNotification.Name.NSManagedObjectContextObjectsDidChange, object: nil, queue: nil) { [weak self] (note) in
-            guard let strongSelf = self else { return }
-            guard strongSelf.enabled else { return }
+            guard let self = self else { return }
+            guard self.enabled else { return }
             let notification = ObjectsDidChangeNotification(notification: note)
-            guard notification.managedObjectContext == strongSelf.context else { return }
-            strongSelf.checkForMatchingObject(in: notification.refreshedObjects, changeType: .refreshed)
-            strongSelf.checkForMatchingObject(in: notification.updatedObjects, changeType: .updated)
-            strongSelf.checkForMatchingObject(in: notification.deletedObjects, changeType: .deleted)
+            guard notification.managedObjectContext == self.context else { return }
+            self.checkForMatchingObject(in: notification.refreshedObjects, changeType: .refreshed)
+            self.checkForMatchingObject(in: notification.updatedObjects, changeType: .updated)
+            self.checkForMatchingObject(in: notification.deletedObjects, changeType: .deleted)
         }
         
         onChange?(object, .initialised)

--- a/Sources/PeakCoreData/Operations/CoreDataBatchDeleteOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataBatchDeleteOperation.swift
@@ -14,7 +14,10 @@ open class CoreDataBatchDeleteOperation<Entity: ManagedObjectType>: CoreDataOper
     private let predicate: NSPredicate?
     private let mergeContexts: [NSManagedObjectContext]?
 
-    public init(predicate: NSPredicate? = nil, mergeContexts: [NSManagedObjectContext]? = nil, persistentContainer: NSPersistentContainer, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
+    public init(predicate: NSPredicate? = nil,
+                mergeContexts: [NSManagedObjectContext]? = nil,
+                persistentContainer: NSPersistentContainer,
+                mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
         self.predicate = predicate
         self.mergeContexts = mergeContexts
         super.init(persistentContainer: persistentContainer, mergePolicyType: mergePolicyType)

--- a/Sources/PeakCoreData/Operations/CoreDataBatchImportOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataBatchImportOperation.swift
@@ -24,14 +24,14 @@ open class CoreDataBatchImportOperation<Intermediate: ManagedObjectUpdatable>: C
             progress.addChild(importProgress, withPendingUnitCount: progress.totalUnitCount)
             
             if let updateProperties = Intermediate.updateProperties {
-                ManagedObject.insertOrUpdate(intermediates: intermediates, in: context, with: cache) { intermediate, managedObject in
+                ManagedObject.insertOrUpdate(intermediates: intermediates, context: context, cache: cache) { intermediate, managedObject in
                     updateProperties(intermediate, managedObject)
                     importProgress.completedUnitCount += 1
                 }
             }
             
             if let updateRelationships = Intermediate.updateRelationships {
-                ManagedObject.insertOrUpdate(intermediates: intermediates, in: context, with: cache) { intermediate, managedObject in
+                ManagedObject.insertOrUpdate(intermediates: intermediates, context: context, cache: cache) { intermediate, managedObject in
                     updateRelationships(intermediate, managedObject, context, self.cache)
                     importProgress.completedUnitCount += 1
                 }

--- a/Sources/PeakCoreData/Operations/CoreDataBatchUpdateOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataBatchUpdateOperation.swift
@@ -15,7 +15,11 @@ open class CoreDataBatchUpdateOperation<Entity: ManagedObjectType>: CoreDataOper
     private let predicate: NSPredicate?
     private let mergeContexts: [NSManagedObjectContext]?
     
-    public init(propertiesToUpdate: [AnyHashable: Any], predicate: NSPredicate? = nil, mergeContexts: [NSManagedObjectContext]? = nil, persistentContainer: NSPersistentContainer, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
+    public init(propertiesToUpdate: [AnyHashable: Any],
+                predicate: NSPredicate? = nil,
+                mergeContexts: [NSManagedObjectContext]? = nil,
+                persistentContainer: NSPersistentContainer,
+                mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
         self.propertiesToUpdate = propertiesToUpdate
         self.predicate = predicate
         self.mergeContexts = mergeContexts

--- a/Sources/PeakCoreData/Operations/CoreDataOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataOperation.swift
@@ -22,7 +22,9 @@ open class CoreDataOperation<Output>: ConcurrentOperation, ProducesResult {
     private(set) public var updated: Set<NSManagedObjectID> = []
     private(set) public var deleted: Set<NSManagedObjectID> = []
 
-    public init(persistentContainer: NSPersistentContainer, cache: ManagedObjectCache? = nil, mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
+    public init(persistentContainer: NSPersistentContainer,
+                cache: ManagedObjectCache? = nil,
+                mergePolicyType: NSMergePolicyType = .mergeByPropertyObjectTrumpMergePolicyType) {
         self.persistentContainer = persistentContainer
         self.mergePolicyType = mergePolicyType
         self.cache = cache

--- a/Sources/PeakCoreData/Operations/CoreDataSingleImportOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataSingleImportOperation.swift
@@ -18,7 +18,7 @@ open class CoreDataSingleImportOperation<Intermediate: ManagedObjectUpdatable>: 
     open override func performWork(in context: NSManagedObjectContext) {
         do {
             let intermediate = try input.get()
-            let managedObject = ManagedObject.fetchOrInsert(with: intermediate.uniqueIDValue, context: context, cache: cache)
+            let managedObject = ManagedObject.fetchOrInsert(withID: intermediate.uniqueIDValue, context: context, cache: cache)
             Intermediate.updateProperties?(intermediate, managedObject)
             Intermediate.updateRelationships?(intermediate, managedObject, context, cache)
             saveAndFinish()

--- a/Sources/PeakCoreData/Operations/CoreDataSingleImportOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataSingleImportOperation.swift
@@ -18,7 +18,7 @@ open class CoreDataSingleImportOperation<Intermediate: ManagedObjectUpdatable>: 
     open override func performWork(in context: NSManagedObjectContext) {
         do {
             let intermediate = try input.get()
-            let managedObject = ManagedObject.fetchOrInsertObject(with: intermediate.uniqueIDValue, context: context, cache: cache)
+            let managedObject = ManagedObject.fetchOrInsert(with: intermediate.uniqueIDValue, context: context, cache: cache)
             Intermediate.updateProperties?(intermediate, managedObject)
             Intermediate.updateRelationships?(intermediate, managedObject, context, cache)
             saveAndFinish()

--- a/Sources/PeakCoreData/Operations/CoreDataSingleImportOperation.swift
+++ b/Sources/PeakCoreData/Operations/CoreDataSingleImportOperation.swift
@@ -18,7 +18,7 @@ open class CoreDataSingleImportOperation<Intermediate: ManagedObjectUpdatable>: 
     open override func performWork(in context: NSManagedObjectContext) {
         do {
             let intermediate = try input.get()
-            let managedObject = ManagedObject.fetchOrInsertObject(with: intermediate.uniqueIDValue, in: context, with: cache)
+            let managedObject = ManagedObject.fetchOrInsertObject(with: intermediate.uniqueIDValue, context: context, cache: cache)
             Intermediate.updateProperties?(intermediate, managedObject)
             Intermediate.updateRelationships?(intermediate, managedObject, context, cache)
             saveAndFinish()

--- a/Sources/PeakCoreData/Protocols/ManagedObjectInitialisable.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectInitialisable.swift
@@ -15,7 +15,7 @@ public protocol ManagedObjectInitialisable {
 
 public extension ManagedObjectType {
     
-    func encode<T>(to type: T.Type, encoder: JSONEncoder) throws -> Data where T: ManagedObjectInitialisable & Codable, T.ManagedObject == Self {
-        return try encoder.encode(T(with: self))
+    func encode<T: ManagedObjectInitialisable & Codable>(to type: T.Type, encoder: JSONEncoder) throws -> Data where T.ManagedObject == Self {
+        try encoder.encode(T(with: self))
     }
 }

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -185,7 +185,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      
      - Note: The managed object must conform to UniqueIdentifiable.
      
-     - parameter uniqueID:  The unique id of the object you want to insert.
+     - parameter id:  The unique id of the object you want to insert.
      - parameter context:   The context to use.
      - parameter cache:     Optional cache to insert new object in to.
      - parameter configure: Optional configuration block to be applied to the inserted object.
@@ -209,7 +209,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      
      - Note: The managed object must conform to UniqueIdentifiable.
      
-     - parameter uniqueID:  The unique id of the object you want to fetch.
+     - parameter id:  The unique id of the object you want to fetch.
      - parameter context:   The context to use.
      - parameter cache:     Optional cache that will be used before performing fetch.
      
@@ -232,7 +232,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      
      - Note: The managed object must conform to UniqueIdentifiable.
      
-     - parameter uniqueID:  The unique id of the object you want to fetch or insert.
+     - parameter id:  The unique id of the object you want to fetch or insert.
      - parameter context:   The context to use.
      - parameter cache:     Optional cache that will be used before performing fetch.
      - parameter configure: Configuration block, which can be used to configure the object once fetched or inserted.

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -33,7 +33,7 @@ public extension ManagedObjectType {
     @discardableResult
     static func insert(in context: NSManagedObjectContext,
                        configure: ManagedObjectConfigurationBlock? = nil) -> Self {
-        guard let object = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context) as? Self else { fatalError("Wrong object type inserted.")}
+        let object: Self = context.insert()
         configure?(object)
         return object
     }

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -193,12 +193,12 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: An initialized and configured instance of the appropriate entity (discardable).
      */
     @discardableResult
-    static func insert(withID uniqueID: UniqueIDType,
+    static func insert(withID id: UniqueIDType,
                        context: NSManagedObjectContext,
                        cache: ManagedObjectCache? = nil,
                        configure: ManagedObjectConfigurationBlock? = nil) -> Self {
         insert(in: context) { object in
-            object.setValue(uniqueID, forKey: uniqueIDKey)
+            object.setValue(id, forKey: uniqueIDKey)
             cache?.register(object, in: context)
             configure?(object)
         }
@@ -215,12 +215,12 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      
      - returns: The object with the specified unique id.
      */
-    static func fetch(withID uniqueID: UniqueIDType,
+    static func fetch(withID id: UniqueIDType,
                       context: NSManagedObjectContext,
                       cache: ManagedObjectCache? = nil) -> Self? {
-        if let cachedObject: Self = cache?.object(withUniqueID: uniqueID, in: context) {
+        if let cachedObject: Self = cache?.object(withUniqueID: id, in: context) {
             return cachedObject
-        } else if let object = first(in: context, matching: uniqueIDValue(equalTo: uniqueID)) {
+        } else if let object = first(in: context, matching: uniqueIDValue(equalTo: id)) {
             cache?.register(object, in: context)
             return object
         }
@@ -240,15 +240,15 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: The object with the specified unique id.
      */
     @discardableResult
-    static func fetchOrInsert(withID uniqueID: UniqueIDType,
+    static func fetchOrInsert(withID id: UniqueIDType,
                               context: NSManagedObjectContext,
                               cache: ManagedObjectCache? = nil,
                               configure: ManagedObjectConfigurationBlock? = nil) -> Self {
-        if let existingObject = fetch(withID: uniqueID, context: context, cache: cache) {
+        if let existingObject = fetch(withID: id, context: context, cache: cache) {
             configure?(existingObject)
             return existingObject
         }
-        return insert(withID: uniqueID, context: context, cache: cache, configure: configure)
+        return insert(withID: id, context: context, cache: cache, configure: configure)
     }
     
     /**

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -183,8 +183,8 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      */
     @discardableResult
     static func insertObject(with uniqueID: UniqueIDType,
-                             in context: NSManagedObjectContext,
-                             with cache: ManagedObjectCache? = nil,
+                             context: NSManagedObjectContext,
+                             cache: ManagedObjectCache? = nil,
                              configure: ManagedObjectConfigurationBlock? = nil) -> Self {
         insertObject(in: context) { object in
             object.setValue(uniqueID, forKey: uniqueIDKey)
@@ -237,7 +237,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
             configure?(existingObject)
             return existingObject
         }
-        return insertObject(with: uniqueID, in: context, with: cache, configure: configure)
+        return insertObject(with: uniqueID, context: context, cache: cache, configure: configure)
     }
     
     /**
@@ -302,7 +302,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
             if let existing = existingObjectsByID[intermediateID] {
                 managedObject = existing
             } else {
-                let new = insertObject(with: intermediateID, in: context)
+                let new = insertObject(with: intermediateID, context: context)
                 managedObject = new
             }
             

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -230,8 +230,8 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      */
     @discardableResult
     static func fetchOrInsertObject(with uniqueID: UniqueIDType,
-                                    in context: NSManagedObjectContext,
-                                    with cache: ManagedObjectCache? = nil,
+                                    context: NSManagedObjectContext,
+                                    cache: ManagedObjectCache? = nil,
                                     configure: ManagedObjectConfigurationBlock? = nil) -> Self {
         if let existingObject = fetchObject(with: uniqueID, in: context, with: cache) {
             configure?(existingObject)

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -258,8 +258,8 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      In both cases the unique identifier will already be set
      */
     static func insertOrUpdate<Intermediate: UniqueIdentifiable>(intermediates: [Intermediate],
-                                                                 in context: NSManagedObjectContext,
-                                                                 with cache: ManagedObjectCache? = nil,
+                                                                 context: NSManagedObjectContext,
+                                                                 cache: ManagedObjectCache? = nil,
                                                                  configure: (Intermediate, Self) -> Void) where UniqueIDType == Intermediate.UniqueIDType {
         
         // Nothing to insert, exit immediately.

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -31,7 +31,8 @@ public extension ManagedObjectType {
      - returns: An initialized and configured instance of the appropriate entity (discardable).
      */
     @discardableResult
-    static func insertObject(in context: NSManagedObjectContext, configure: ManagedObjectConfigurationBlock? = nil) -> Self {
+    static func insert(in context: NSManagedObjectContext,
+                       configure: ManagedObjectConfigurationBlock? = nil) -> Self {
         guard let object = NSEntityDescription.insertNewObject(forEntityName: entityName, into: context) as? Self else { fatalError("Wrong object type inserted.")}
         configure?(object)
         return object
@@ -57,7 +58,8 @@ public extension ManagedObjectType {
      
      - returns: An array of objects matching the configured fetch request, sorted by `defaultSortDescriptors`.
      */
-    static func fetch(in context: NSManagedObjectContext, configure: FetchRequestConfigurationBlock? = nil) -> [Self] {
+    static func fetch(in context: NSManagedObjectContext,
+                      configure: FetchRequestConfigurationBlock? = nil) -> [Self] {
         let request = sortedFetchRequest(configure: configure)
         do {
             return try context.fetch(request)
@@ -72,7 +74,8 @@ public extension ManagedObjectType {
      
      - returns: The first object matching the configured fetch request.
      */
-    static func first(in context: NSManagedObjectContext, configure: FetchRequestConfigurationBlock? = nil) -> Self? {
+    static func first(in context: NSManagedObjectContext,
+                      configure: FetchRequestConfigurationBlock? = nil) -> Self? {
         let request = sortedFetchRequest(configure: configure)
         request.fetchLimit = 1
         do {
@@ -89,7 +92,8 @@ public extension ManagedObjectType {
      
      - returns: The first object matching the provided predicate.
      */
-    static func first(in context: NSManagedObjectContext, matching predicate: NSPredicate? = nil) -> Self? {
+    static func first(in context: NSManagedObjectContext,
+                      matching predicate: NSPredicate? = nil) -> Self? {
         let request = NSFetchRequest<Self>(entityName: entityName)
         request.predicate = predicate
         request.fetchLimit = 1
@@ -107,7 +111,8 @@ public extension ManagedObjectType {
      
      - returns: The count of all objects or all objects matching the predicate.
      */
-    static func count(in context: NSManagedObjectContext, matching predicate: NSPredicate? = nil) -> Int {
+    static func count(in context: NSManagedObjectContext,
+                      matching predicate: NSPredicate? = nil) -> Int {
         let countRequest = NSFetchRequest<Self>(entityName: entityName)
         countRequest.predicate = predicate
         do {
@@ -123,7 +128,8 @@ public extension ManagedObjectType {
      - parameter context:       The context to use.
      - parameter predicate:     Optional predicate to be applied to the fetch request.
      */
-    static func delete(in context: NSManagedObjectContext, matching predicate: NSPredicate? = nil) {
+    static func delete(in context: NSManagedObjectContext,
+                       matching predicate: NSPredicate? = nil) {
         let deleteRequest = NSFetchRequest<Self>(entityName: entityName)
         deleteRequest.predicate = predicate
         deleteRequest.includesPropertyValues = false
@@ -182,11 +188,11 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: An initialized and configured instance of the appropriate entity (discardable).
      */
     @discardableResult
-    static func insertObject(with uniqueID: UniqueIDType,
-                             context: NSManagedObjectContext,
-                             cache: ManagedObjectCache? = nil,
-                             configure: ManagedObjectConfigurationBlock? = nil) -> Self {
-        insertObject(in: context) { object in
+    static func insert(with uniqueID: UniqueIDType,
+                       context: NSManagedObjectContext,
+                       cache: ManagedObjectCache? = nil,
+                       configure: ManagedObjectConfigurationBlock? = nil) -> Self {
+        insert(in: context) { object in
             object.setValue(uniqueID, forKey: uniqueIDKey)
             cache?.register(object, in: context)
             configure?(object)
@@ -204,9 +210,9 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      
      - returns: The object with the specified unique id.
      */
-    static func fetchObject(with uniqueID: UniqueIDType,
-                            context: NSManagedObjectContext,
-                            cache: ManagedObjectCache? = nil) -> Self? {
+    static func fetch(with uniqueID: UniqueIDType,
+                      context: NSManagedObjectContext,
+                      cache: ManagedObjectCache? = nil) -> Self? {
         if let cachedObject: Self = cache?.object(withUniqueID: uniqueID, in: context) {
             return cachedObject
         } else if let object = first(in: context, matching: uniqueObjectPredicate(with: uniqueID)) {
@@ -229,15 +235,15 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: The object with the specified unique id.
      */
     @discardableResult
-    static func fetchOrInsertObject(with uniqueID: UniqueIDType,
-                                    context: NSManagedObjectContext,
-                                    cache: ManagedObjectCache? = nil,
-                                    configure: ManagedObjectConfigurationBlock? = nil) -> Self {
-        if let existingObject = fetchObject(with: uniqueID, context: context, cache: cache) {
+    static func fetchOrInsert(with uniqueID: UniqueIDType,
+                              context: NSManagedObjectContext,
+                              cache: ManagedObjectCache? = nil,
+                              configure: ManagedObjectConfigurationBlock? = nil) -> Self {
+        if let existingObject = fetch(with: uniqueID, context: context, cache: cache) {
             configure?(existingObject)
             return existingObject
         }
-        return insertObject(with: uniqueID, context: context, cache: cache, configure: configure)
+        return insert(with: uniqueID, context: context, cache: cache, configure: configure)
     }
     
     /**
@@ -263,7 +269,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
                                                                  configure: (Intermediate, Self) -> Void) where UniqueIDType == Intermediate.UniqueIDType {
         
         // Nothing to insert, exit immediately.
-
+        
         guard !intermediates.isEmpty else { return }
         
         // Configure the cached objects first.
@@ -302,7 +308,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
             if let existing = existingObjectsByID[intermediateID] {
                 managedObject = existing
             } else {
-                let new = insertObject(with: intermediateID, context: context)
+                let new = insert(with: intermediateID, context: context)
                 managedObject = new
             }
             

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -75,7 +75,7 @@ public extension ManagedObjectType {
      - returns: An array of objects matching the configured fetch request, sorted by `defaultSortDescriptors`.
      */
     static func fetch(in context: NSManagedObjectContext,
-                      predicate: NSPredicate) -> [Self] {
+                      matching predicate: NSPredicate) -> [Self] {
         let request = sortedFetchRequest { $0.predicate = predicate }
         do {
             return try context.fetch(request)
@@ -109,7 +109,7 @@ public extension ManagedObjectType {
      - returns: The first object matching the provided predicate.
      */
     static func first(in context: NSManagedObjectContext,
-                      predicate: NSPredicate) -> Self? {
+                      matching predicate: NSPredicate) -> Self? {
         let request = NSFetchRequest<Self>(entityName: entityName)
         request.predicate = predicate
         request.fetchLimit = 1
@@ -128,7 +128,7 @@ public extension ManagedObjectType {
      - returns: The count of all objects or all objects matching the predicate.
      */
     static func count(in context: NSManagedObjectContext,
-                      predicate: NSPredicate? = nil) -> Int {
+                      matching predicate: NSPredicate? = nil) -> Int {
         let countRequest = NSFetchRequest<Self>(entityName: entityName)
         countRequest.predicate = predicate
         do {
@@ -145,7 +145,7 @@ public extension ManagedObjectType {
      - parameter predicate:     Optional predicate to be applied to the fetch request.
      */
     static func delete(in context: NSManagedObjectContext,
-                       predicate: NSPredicate? = nil) {
+                       matching predicate: NSPredicate? = nil) {
         let deleteRequest = NSFetchRequest<Self>(entityName: entityName)
         deleteRequest.predicate = predicate
         deleteRequest.includesPropertyValues = false
@@ -162,17 +162,17 @@ public extension ManagedObjectType {
      `NSManagedObjectContext` can be provided into which the deletions can be merged using the
      `mergeChanges(fromRemoteContextSave:into:)` function on `NSManagedObjectContext`.
      
-     - This should be significantly faster than `delete(in:predicate)` for large datasets.
-     - This is a convenience function for calling `batchDelete(in:predicate:mergeContexts:)` on `NSEntityDescription`.
+     - This should be significantly faster than `delete(in:matching)` for large datasets.
+     - This is a convenience function for calling `batchDelete(in:matching:mergeContexts:)` on `NSEntityDescription`.
      
      - parameter context:       The context to use.
      - parameter predicate:     Optional predicate to be applied to the fetch request.
      - parameter mergeContexts: Optional contexts into which changes can be merged.
      */
     static func batchDelete(in context: NSManagedObjectContext,
-                            predicate: NSPredicate? = nil,
+                            matching predicate: NSPredicate? = nil,
                             mergeContexts: [NSManagedObjectContext]? = nil) {
-        entity().batchDelete(in: context, predicate: predicate, mergeContexts: mergeContexts)
+        entity().batchDelete(in: context, matching: predicate, mergeContexts: mergeContexts)
     }
 }
 
@@ -220,7 +220,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
                       cache: ManagedObjectCache? = nil) -> Self? {
         if let cachedObject: Self = cache?.object(withUniqueID: uniqueID, in: context) {
             return cachedObject
-        } else if let object = first(in: context, predicate: uniqueIDValue(equalTo: uniqueID)) {
+        } else if let object = first(in: context, matching: uniqueIDValue(equalTo: uniqueID)) {
             cache?.register(object, in: context)
             return object
         }

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -205,8 +205,8 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: The object with the specified unique id.
      */
     static func fetchObject(with uniqueID: UniqueIDType,
-                            in context: NSManagedObjectContext,
-                            with cache: ManagedObjectCache? = nil) -> Self? {
+                            context: NSManagedObjectContext,
+                            cache: ManagedObjectCache? = nil) -> Self? {
         if let cachedObject: Self = cache?.object(withUniqueID: uniqueID, in: context) {
             return cachedObject
         } else if let object = first(in: context, matching: uniqueObjectPredicate(with: uniqueID)) {
@@ -233,7 +233,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
                                     context: NSManagedObjectContext,
                                     cache: ManagedObjectCache? = nil,
                                     configure: ManagedObjectConfigurationBlock? = nil) -> Self {
-        if let existingObject = fetchObject(with: uniqueID, in: context, with: cache) {
+        if let existingObject = fetchObject(with: uniqueID, context: context, cache: cache) {
             configure?(existingObject)
             return existingObject
         }

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -165,17 +165,6 @@ public extension ManagedObjectType {
 public extension ManagedObjectType where Self: UniqueIdentifiable {
     
     /**
-     - Note: The managed object must conform to UniqueIdentifiable.
-     
-     - parameter uniqueID:  The unique id of the object you want to fetch.
-     
-     - returns: A predicate that can be used to fetch a single object with the specified unique id.
-     */
-    static func uniqueObjectPredicate(with uniqueKeyValue: UniqueIDType) -> NSPredicate {
-        NSPredicate(equalTo: uniqueKeyValue, keyPath: uniqueIDKey)
-    }
-    
-    /**
      Inserts an object in to the context, applies the unique id and then configures the object (optional).
      
      - Note: The managed object must conform to UniqueIdentifiable.
@@ -188,7 +177,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: An initialized and configured instance of the appropriate entity (discardable).
      */
     @discardableResult
-    static func insert(with uniqueID: UniqueIDType,
+    static func insert(withID uniqueID: UniqueIDType,
                        context: NSManagedObjectContext,
                        cache: ManagedObjectCache? = nil,
                        configure: ManagedObjectConfigurationBlock? = nil) -> Self {
@@ -210,12 +199,12 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      
      - returns: The object with the specified unique id.
      */
-    static func fetch(with uniqueID: UniqueIDType,
+    static func fetch(withID uniqueID: UniqueIDType,
                       context: NSManagedObjectContext,
                       cache: ManagedObjectCache? = nil) -> Self? {
         if let cachedObject: Self = cache?.object(withUniqueID: uniqueID, in: context) {
             return cachedObject
-        } else if let object = first(in: context, matching: uniqueObjectPredicate(with: uniqueID)) {
+        } else if let object = first(in: context, matching: uniqueIDValue(equalTo: uniqueID)) {
             cache?.register(object, in: context)
             return object
         }
@@ -235,15 +224,15 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
      - returns: The object with the specified unique id.
      */
     @discardableResult
-    static func fetchOrInsert(with uniqueID: UniqueIDType,
+    static func fetchOrInsert(withID uniqueID: UniqueIDType,
                               context: NSManagedObjectContext,
                               cache: ManagedObjectCache? = nil,
                               configure: ManagedObjectConfigurationBlock? = nil) -> Self {
-        if let existingObject = fetch(with: uniqueID, context: context, cache: cache) {
+        if let existingObject = fetch(withID: uniqueID, context: context, cache: cache) {
             configure?(existingObject)
             return existingObject
         }
-        return insert(with: uniqueID, context: context, cache: cache, configure: configure)
+        return insert(withID: uniqueID, context: context, cache: cache, configure: configure)
     }
     
     /**
@@ -308,7 +297,7 @@ public extension ManagedObjectType where Self: UniqueIdentifiable {
             if let existing = existingObjectsByID[intermediateID] {
                 managedObject = existing
             } else {
-                let new = insert(with: intermediateID, context: context)
+                let new = insert(withID: intermediateID, context: context)
                 managedObject = new
             }
             

--- a/Sources/PeakCoreData/Protocols/PersistentContainerSettable.swift
+++ b/Sources/PeakCoreData/Protocols/PersistentContainerSettable.swift
@@ -14,9 +14,7 @@ public protocol PersistentContainerSettable: AnyObject {
 
 public extension PersistentContainerSettable {
     
-    var viewContext: NSManagedObjectContext {
-        return persistentContainer.viewContext
-    }
+    var viewContext: NSManagedObjectContext { persistentContainer.viewContext }
     
     func saveViewContext() {
         guard viewContext.hasChanges else { return }

--- a/Sources/PeakCoreData/Protocols/UniqueIdentifiable.swift
+++ b/Sources/PeakCoreData/Protocols/UniqueIdentifiable.swift
@@ -13,3 +13,10 @@ public protocol UniqueIdentifiable {
     static var uniqueIDKey: String { get }
     var uniqueIDValue: UniqueIDType { get }
 }
+
+public extension UniqueIdentifiable {
+    
+    static func uniqueIDValue(equalTo value: UniqueIDType) -> NSPredicate {
+        NSPredicate(equalTo: value, keyPath: uniqueIDKey)
+    }
+}

--- a/Tests/PeakCoreDataTests/CoreDataTests.swift
+++ b/Tests/PeakCoreDataTests/CoreDataTests.swift
@@ -14,7 +14,7 @@ let defaultTimeout = TimeInterval(2)
 
 class CoreDataTests: XCTestCase, PersistentContainerSettable {
     
-    var managedObjectCache: ManagedObjectCache!
+    var cache: ManagedObjectCache!
     var persistentContainer: NSPersistentContainer!
     var lastIndex: Int32 = 0
     
@@ -33,14 +33,14 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             }
         }
         persistentContainer.viewContext.automaticallyMergesChangesFromParent = true
-        managedObjectCache = ManagedObjectCache()
+        cache = ManagedObjectCache()
         lastIndex = 0
     }
     
     override func tearDown() {
         lastIndex = 0
         persistentContainer = nil
-        managedObjectCache = nil
+        cache = nil
         super.tearDown()
     }
     

--- a/Tests/PeakCoreDataTests/CoreDataTests.swift
+++ b/Tests/PeakCoreDataTests/CoreDataTests.swift
@@ -56,7 +56,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityString.insert(with: id, context: viewContext)
+                TestEntityString.insert(withID: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -74,7 +74,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityUUID.insert(with: id, context: viewContext)
+                TestEntityUUID.insert(withID: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -94,7 +94,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityInt.insert(with: id, context: viewContext)
+                TestEntityInt.insert(withID: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -105,7 +105,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         var items: [TestEntityString] = []
         for index in 0..<count {
             let id = UUID().uuidString
-            let newObject = TestEntityString.insert(with: id, context: viewContext) {
+            let newObject = TestEntityString.insert(withID: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)
@@ -120,7 +120,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         for index in 0..<count {
             let id = Int32(index) + toAdd
             lastIndex = id
-            let newObject = TestEntityInt.insert(with: id, context: viewContext) {
+            let newObject = TestEntityInt.insert(withID: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)
@@ -133,7 +133,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         var items: [TestEntityUUID] = []
         for index in 0..<count {
             let id = UUID()
-            let newObject = TestEntityUUID.insert(with: id, context: viewContext) {
+            let newObject = TestEntityUUID.insert(withID: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)

--- a/Tests/PeakCoreDataTests/CoreDataTests.swift
+++ b/Tests/PeakCoreDataTests/CoreDataTests.swift
@@ -56,7 +56,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityString.insertObject(with: id, context: viewContext)
+                TestEntityString.insert(with: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -74,7 +74,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityUUID.insertObject(with: id, context: viewContext)
+                TestEntityUUID.insert(with: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -94,7 +94,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityInt.insertObject(with: id, context: viewContext)
+                TestEntityInt.insert(with: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -105,7 +105,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         var items: [TestEntityString] = []
         for index in 0..<count {
             let id = UUID().uuidString
-            let newObject = TestEntityString.insertObject(with: id, context: viewContext) {
+            let newObject = TestEntityString.insert(with: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)
@@ -120,7 +120,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         for index in 0..<count {
             let id = Int32(index) + toAdd
             lastIndex = id
-            let newObject = TestEntityInt.insertObject(with: id, context: viewContext) {
+            let newObject = TestEntityInt.insert(with: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)
@@ -133,7 +133,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         var items: [TestEntityUUID] = []
         for index in 0..<count {
             let id = UUID()
-            let newObject = TestEntityUUID.insertObject(with: id, context: viewContext) {
+            let newObject = TestEntityUUID.insert(with: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)

--- a/Tests/PeakCoreDataTests/CoreDataTests.swift
+++ b/Tests/PeakCoreDataTests/CoreDataTests.swift
@@ -56,7 +56,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityString.insertObject(with: id, in: viewContext)
+                TestEntityString.insertObject(with: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -74,7 +74,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityUUID.insertObject(with: id, in: viewContext)
+                TestEntityUUID.insertObject(with: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -94,7 +94,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
             // Create a managed object for half the items, to check that they are correctly updated
             
             if test(index) {
-                TestEntityInt.insertObject(with: id, in: viewContext)
+                TestEntityInt.insertObject(with: id, context: viewContext)
             }
         }
         return intermediateItems
@@ -105,7 +105,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         var items: [TestEntityString] = []
         for index in 0..<count {
             let id = UUID().uuidString
-            let newObject = TestEntityString.insertObject(with: id, in: viewContext) {
+            let newObject = TestEntityString.insertObject(with: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)
@@ -120,7 +120,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         for index in 0..<count {
             let id = Int32(index) + toAdd
             lastIndex = id
-            let newObject = TestEntityInt.insertObject(with: id, in: viewContext) {
+            let newObject = TestEntityInt.insertObject(with: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)
@@ -133,7 +133,7 @@ class CoreDataTests: XCTestCase, PersistentContainerSettable {
         var items: [TestEntityUUID] = []
         for index in 0..<count {
             let id = UUID()
-            let newObject = TestEntityUUID.insertObject(with: id, in: viewContext) {
+            let newObject = TestEntityUUID.insertObject(with: id, context: viewContext) {
                 $0.title = "Item \(index)"
             }
             items.append(newObject)

--- a/Tests/PeakCoreDataTests/CountObserverTests.swift
+++ b/Tests/PeakCoreDataTests/CountObserverTests.swift
@@ -124,7 +124,7 @@ class CountObserverTests: CoreDataTests {
         expect.expectedFulfillmentCount = 2
         
         let predicate = NSPredicate(stringBeginsWith: "A", keyPath: #keyPath(TestEntityString.uniqueID))
-        let count1 = TestEntityString.count(in: viewContext, matching: predicate)
+        let count1 = TestEntityString.count(in: viewContext, predicate: predicate)
         
         let observer = CountObserver<TestEntityString>(predicate: predicate, context: viewContext)
         XCTAssertEqual(observer.count, count1)
@@ -137,7 +137,7 @@ class CountObserverTests: CoreDataTests {
         }
         
         createTestEntityStringObjects(count: insertNumber)
-        let count2 = TestEntityString.count(in: viewContext, matching: predicate)
+        let count2 = TestEntityString.count(in: viewContext, predicate: predicate)
         
         waitForExpectations(timeout: defaultTimeout)
         

--- a/Tests/PeakCoreDataTests/CountObserverTests.swift
+++ b/Tests/PeakCoreDataTests/CountObserverTests.swift
@@ -124,7 +124,7 @@ class CountObserverTests: CoreDataTests {
         expect.expectedFulfillmentCount = 2
         
         let predicate = NSPredicate(stringBeginsWith: "A", keyPath: #keyPath(TestEntityString.uniqueID))
-        let count1 = TestEntityString.count(in: viewContext, predicate: predicate)
+        let count1 = TestEntityString.count(in: viewContext, matching: predicate)
         
         let observer = CountObserver<TestEntityString>(predicate: predicate, context: viewContext)
         XCTAssertEqual(observer.count, count1)
@@ -137,7 +137,7 @@ class CountObserverTests: CoreDataTests {
         }
         
         createTestEntityStringObjects(count: insertNumber)
-        let count2 = TestEntityString.count(in: viewContext, predicate: predicate)
+        let count2 = TestEntityString.count(in: viewContext, matching: predicate)
         
         waitForExpectations(timeout: defaultTimeout)
         

--- a/Tests/PeakCoreDataTests/FetchedCollectionTests.swift
+++ b/Tests/PeakCoreDataTests/FetchedCollectionTests.swift
@@ -223,7 +223,7 @@ class FetchedCollectionTests: CoreDataTests {
         createTestEntityStringObjects(count: 9)
         
         let uniqueID = "testid"
-        TestEntityString.insertObject(with: uniqueID, context: viewContext)
+        TestEntityString.insert(with: uniqueID, context: viewContext)
         
         let fetchedCollection = createFetchedCollection()
         

--- a/Tests/PeakCoreDataTests/FetchedCollectionTests.swift
+++ b/Tests/PeakCoreDataTests/FetchedCollectionTests.swift
@@ -223,7 +223,7 @@ class FetchedCollectionTests: CoreDataTests {
         createTestEntityStringObjects(count: 9)
         
         let uniqueID = "testid"
-        TestEntityString.insertObject(with: uniqueID, in: viewContext)
+        TestEntityString.insertObject(with: uniqueID, context: viewContext)
         
         let fetchedCollection = createFetchedCollection()
         

--- a/Tests/PeakCoreDataTests/FetchedCollectionTests.swift
+++ b/Tests/PeakCoreDataTests/FetchedCollectionTests.swift
@@ -223,7 +223,7 @@ class FetchedCollectionTests: CoreDataTests {
         createTestEntityStringObjects(count: 9)
         
         let uniqueID = "testid"
-        TestEntityString.insert(with: uniqueID, context: viewContext)
+        TestEntityString.insert(withID: uniqueID, context: viewContext)
         
         let fetchedCollection = createFetchedCollection()
         

--- a/Tests/PeakCoreDataTests/ManagedObjectCacheTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectCacheTests.swift
@@ -111,8 +111,8 @@ class ManagedObjectCacheTests: CoreDataTests {
         let anotherEntities = createTestEntityIntObjects(count: insertNumber)
         XCTAssertEqual((anotherEntities.filter { $0.objectID.isTemporaryID }).count, insertNumber)
         
-        managedObjectCache.register(testEntities, in: viewContext)
-        managedObjectCache.register(anotherEntities, in: viewContext)
+        cache.register(testEntities, in: viewContext)
+        cache.register(anotherEntities, in: viewContext)
 
         XCTAssertEqual((testEntities.filter { $0.objectID.isTemporaryID }).count, 0)
         XCTAssertEqual((anotherEntities.filter { $0.objectID.isTemporaryID }).count, 0)
@@ -123,16 +123,16 @@ class ManagedObjectCacheTests: CoreDataTests {
         let testEntities = createTestEntityStringObjects(count: insertNumber)
         let anotherEntities = createTestEntityIntObjects(count: insertNumber)
 
-        managedObjectCache.register(testEntities, in: viewContext)
-        managedObjectCache.register(anotherEntities, in: viewContext)
+        cache.register(testEntities, in: viewContext)
+        cache.register(anotherEntities, in: viewContext)
 
         testEntities.forEach { obj in
-            let cached: TestEntityString? = managedObjectCache.object(withUniqueID: obj.uniqueIDValue, in: viewContext)
+            let cached: TestEntityString? = cache.object(withUniqueID: obj.uniqueIDValue, in: viewContext)
             XCTAssertNotNil(cached)
         }
         
         anotherEntities.forEach { obj in
-            let cached: TestEntityInt? = managedObjectCache.object(withUniqueID: obj.uniqueIDValue, in: viewContext)
+            let cached: TestEntityInt? = cache.object(withUniqueID: obj.uniqueIDValue, in: viewContext)
             XCTAssertNotNil(cached)
         }
     }

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -14,22 +14,22 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testFetchObject() {
         let id1 = UUID().uuidString
-        TestEntityString.insertObject(with: id1, context: viewContext)
-        XCTAssertNotNil(TestEntityString.fetchObject(with: id1, context: viewContext))
+        TestEntityString.insert(with: id1, context: viewContext)
+        XCTAssertNotNil(TestEntityString.fetch(with: id1, context: viewContext))
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        TestEntityInt.insertObject(with: id2, context: viewContext)
-        XCTAssertNotNil(TestEntityInt.fetchObject(with: id2, context: viewContext))
+        TestEntityInt.insert(with: id2, context: viewContext)
+        XCTAssertNotNil(TestEntityInt.fetch(with: id2, context: viewContext))
     }
     
     func testFirstMatchingPredicate() {
         let id1 = UUID().uuidString
-        TestEntityString.insertObject(with: id1, context: viewContext)
+        TestEntityString.insert(with: id1, context: viewContext)
         let predicate1 = TestEntityString.uniqueObjectPredicate(with: id1)
         XCTAssertNotNil(TestEntityString.first(in: viewContext, matching: predicate1))
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        TestEntityInt.insertObject(with: id2, context: viewContext)
+        TestEntityInt.insert(with: id2, context: viewContext)
         let predicate2 = TestEntityInt.uniqueObjectPredicate(with: id2)
         XCTAssertNotNil(TestEntityInt.first(in: viewContext, matching: predicate2))
     }
@@ -95,13 +95,13 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testInsertOrFetchObject() {
         let id1 = UUID().uuidString
-        let item1 = TestEntityString.fetchOrInsertObject(with: id1, context: viewContext, cache: cache)
-        let item2 = TestEntityString.fetchOrInsertObject(with: id1, context: viewContext, cache: cache)
+        let item1 = TestEntityString.fetchOrInsert(with: id1, context: viewContext, cache: cache)
+        let item2 = TestEntityString.fetchOrInsert(with: id1, context: viewContext, cache: cache)
         XCTAssertEqual(item1, item2)
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        let item3 = TestEntityInt.fetchOrInsertObject(with: id2, context: viewContext, cache: cache)
-        let item4 = TestEntityInt.fetchOrInsertObject(with: id2, context: viewContext, cache: cache)
+        let item3 = TestEntityInt.fetchOrInsert(with: id2, context: viewContext, cache: cache)
+        let item4 = TestEntityInt.fetchOrInsert(with: id2, context: viewContext, cache: cache)
         XCTAssertEqual(item3, item4)
     }
     
@@ -234,13 +234,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -254,13 +254,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -274,13 +274,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -294,13 +294,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -311,7 +311,7 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testEncodingTestEntityToData() {
         let id = UUID().uuidString
-        let item1 = TestEntityString.fetchOrInsertObject(with: id, context: viewContext, cache: cache)
+        let item1 = TestEntityString.fetchOrInsert(with: id, context: viewContext, cache: cache)
         item1.title = "Hello"
         
         let data = try! item1.encode(to: TestEntityStringJSON.self, encoder: JSONEncoder())
@@ -325,7 +325,7 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testEncodingTestEntityIntToData() {
         let id = Int32.random(in: 0..<Int32.max)
-        let item1 = TestEntityInt.fetchOrInsertObject(with: id, context: viewContext, cache: cache)
+        let item1 = TestEntityInt.fetchOrInsert(with: id, context: viewContext, cache: cache)
         item1.title = "Hello"
         
         let data = try! item1.encode(to: TestEntityIntJSON.self, encoder: JSONEncoder())

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -14,22 +14,22 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testFetchObject() {
         let id1 = UUID().uuidString
-        TestEntityString.insertObject(with: id1, in: viewContext)
+        TestEntityString.insertObject(with: id1, context: viewContext)
         XCTAssertNotNil(TestEntityString.fetchObject(with: id1, context: viewContext))
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        TestEntityInt.insertObject(with: id2, in: viewContext)
+        TestEntityInt.insertObject(with: id2, context: viewContext)
         XCTAssertNotNil(TestEntityInt.fetchObject(with: id2, context: viewContext))
     }
     
     func testFirstMatchingPredicate() {
         let id1 = UUID().uuidString
-        TestEntityString.insertObject(with: id1, in: viewContext)
+        TestEntityString.insertObject(with: id1, context: viewContext)
         let predicate1 = TestEntityString.uniqueObjectPredicate(with: id1)
         XCTAssertNotNil(TestEntityString.first(in: viewContext, matching: predicate1))
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        TestEntityInt.insertObject(with: id2, in: viewContext)
+        TestEntityInt.insertObject(with: id2, context: viewContext)
         let predicate2 = TestEntityInt.uniqueObjectPredicate(with: id2)
         XCTAssertNotNil(TestEntityInt.first(in: viewContext, matching: predicate2))
     }

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -95,13 +95,13 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testInsertOrFetchObject() {
         let id1 = UUID().uuidString
-        let item1 = TestEntityString.fetchOrInsertObject(with: id1, in: viewContext, with: managedObjectCache)
-        let item2 = TestEntityString.fetchOrInsertObject(with: id1, in: viewContext, with: managedObjectCache)
+        let item1 = TestEntityString.fetchOrInsertObject(with: id1, context: viewContext, cache: cache)
+        let item2 = TestEntityString.fetchOrInsertObject(with: id1, context: viewContext, cache: cache)
         XCTAssertEqual(item1, item2)
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        let item3 = TestEntityInt.fetchOrInsertObject(with: id2, in: viewContext, with: managedObjectCache)
-        let item4 = TestEntityInt.fetchOrInsertObject(with: id2, in: viewContext, with: managedObjectCache)
+        let item3 = TestEntityInt.fetchOrInsertObject(with: id2, context: viewContext, cache: cache)
+        let item4 = TestEntityInt.fetchOrInsertObject(with: id2, context: viewContext, cache: cache)
         XCTAssertEqual(item3, item4)
     }
     
@@ -111,7 +111,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         XCTAssertEqual(TestEntityString.count(in: viewContext), (expectedCount/2), "Count before update should be equal to half expected count")
 
-        TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) {
+        TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
         }
@@ -122,7 +122,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         XCTAssertEqual(TestEntityInt.count(in: viewContext), (expectedCount/2), "Count before update should be equal to half expected count")
 
-        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: managedObjectCache) {
+        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: cache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
         }
@@ -134,11 +134,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let expectedCount = 10
         let intermediateItems = createTestEntityStringIntermediates(count: expectedCount)
         
-        TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) {
+        TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
             
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) {
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) {
                 (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
@@ -149,11 +149,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         let intermediateItems2 = createTestEntityIntIntermediates(count: expectedCount)
         
-        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: managedObjectCache) {
+        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: cache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
             
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: managedObjectCache) {
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: cache) {
                 (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
@@ -200,11 +200,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let insertCount = 100
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
@@ -217,11 +217,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let insertCount = 100
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: cache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
@@ -234,13 +234,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext) { entity in
+                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext) { entity in
+                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -254,13 +254,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext) { entity in
+                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext) { entity in
+                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -274,13 +274,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext, with: managedObjectCache) { entity in
+                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext, with: managedObjectCache) { entity in
+                TestEntityString.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -294,13 +294,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext, with: managedObjectCache) { entity in
+                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, in: viewContext, with: managedObjectCache) { entity in
+                TestEntityInt.fetchOrInsertObject(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -311,7 +311,7 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testEncodingTestEntityToData() {
         let id = UUID().uuidString
-        let item1 = TestEntityString.fetchOrInsertObject(with: id, in: viewContext, with: managedObjectCache)
+        let item1 = TestEntityString.fetchOrInsertObject(with: id, context: viewContext, cache: cache)
         item1.title = "Hello"
         
         let data = try! item1.encode(to: TestEntityStringJSON.self, encoder: JSONEncoder())
@@ -325,7 +325,7 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testEncodingTestEntityIntToData() {
         let id = Int32.random(in: 0..<Int32.max)
-        let item1 = TestEntityInt.fetchOrInsertObject(with: id, in: viewContext, with: managedObjectCache)
+        let item1 = TestEntityInt.fetchOrInsertObject(with: id, context: viewContext, cache: cache)
         item1.title = "Hello"
         
         let data = try! item1.encode(to: TestEntityIntJSON.self, encoder: JSONEncoder())

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -26,12 +26,12 @@ class ManagedObjectTypeTests: CoreDataTests {
         let id1 = UUID().uuidString
         TestEntityString.insert(withID: id1, context: viewContext)
         let predicate1 = TestEntityString.uniqueIDValue(equalTo: id1)
-        XCTAssertNotNil(TestEntityString.first(in: viewContext, matching: predicate1))
+        XCTAssertNotNil(TestEntityString.first(in: viewContext, predicate: predicate1))
         
         let id2 = Int32.random(in: 0..<Int32.max)
         TestEntityInt.insert(withID: id2, context: viewContext)
         let predicate2 = TestEntityInt.uniqueIDValue(equalTo: id2)
-        XCTAssertNotNil(TestEntityInt.first(in: viewContext, matching: predicate2))
+        XCTAssertNotNil(TestEntityInt.first(in: viewContext, predicate: predicate2))
     }
     
     func testFirstConfigured() {
@@ -78,7 +78,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         XCTAssertEqual(TestEntityString.count(in: viewContext), count)
         
         let predicate1 = TestEntityString.uniqueIDValue(equalTo: itemToDelete1.uniqueIDValue)
-        TestEntityString.delete(in: viewContext, matching: predicate1)
+        TestEntityString.delete(in: viewContext, predicate: predicate1)
         
         XCTAssertEqual(TestEntityString.count(in: viewContext), count-1)
         
@@ -88,7 +88,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         XCTAssertEqual(TestEntityInt.count(in: viewContext), count)
         
         let predicate2 = TestEntityInt.uniqueIDValue(equalTo: itemToDelete2.uniqueIDValue)
-        TestEntityInt.delete(in: viewContext, matching: predicate2)
+        TestEntityInt.delete(in: viewContext, predicate: predicate2)
         
         XCTAssertEqual(TestEntityInt.count(in: viewContext), count-1)
     }

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -111,7 +111,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         XCTAssertEqual(TestEntityString.count(in: viewContext), (expectedCount/2), "Count before update should be equal to half expected count")
 
-        TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) {
+        TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
         }
@@ -122,7 +122,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         XCTAssertEqual(TestEntityInt.count(in: viewContext), (expectedCount/2), "Count before update should be equal to half expected count")
 
-        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, in: viewContext, with: managedObjectCache) {
+        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: managedObjectCache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
         }
@@ -134,11 +134,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let expectedCount = 10
         let intermediateItems = createTestEntityStringIntermediates(count: expectedCount)
         
-        TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) {
+        TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
             
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) {
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) {
                 (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
@@ -149,11 +149,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         let intermediateItems2 = createTestEntityIntIntermediates(count: expectedCount)
         
-        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, in: viewContext, with: managedObjectCache) {
+        TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: managedObjectCache) {
             (intermediate, managedObject) in
             managedObject.title = intermediate.title
             
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, in: viewContext, with: managedObjectCache) {
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems2, context: viewContext, cache: managedObjectCache) {
                 (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
@@ -167,11 +167,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let insertCount = 100
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext) { (intermediate, managedObject) in
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext) { (intermediate, managedObject) in
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
@@ -183,11 +183,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let insertCount = 100
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, in: viewContext) { (intermediate, managedObject) in
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, in: viewContext) { (intermediate, managedObject) in
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
@@ -200,11 +200,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let insertCount = 100
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
-            TestEntityString.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityString.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
@@ -217,11 +217,11 @@ class ManagedObjectTypeTests: CoreDataTests {
         let insertCount = 100
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             
-            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, in: viewContext, with: managedObjectCache) { (intermediate, managedObject) in
+            TestEntityInt.insertOrUpdate(intermediates: intermediateItems, context: viewContext, cache: managedObjectCache) { (intermediate, managedObject) in
                 managedObject.title = intermediate.title
             }
             

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -26,12 +26,12 @@ class ManagedObjectTypeTests: CoreDataTests {
         let id1 = UUID().uuidString
         TestEntityString.insert(withID: id1, context: viewContext)
         let predicate1 = TestEntityString.uniqueIDValue(equalTo: id1)
-        XCTAssertNotNil(TestEntityString.first(in: viewContext, predicate: predicate1))
+        XCTAssertNotNil(TestEntityString.first(in: viewContext, matching: predicate1))
         
         let id2 = Int32.random(in: 0..<Int32.max)
         TestEntityInt.insert(withID: id2, context: viewContext)
         let predicate2 = TestEntityInt.uniqueIDValue(equalTo: id2)
-        XCTAssertNotNil(TestEntityInt.first(in: viewContext, predicate: predicate2))
+        XCTAssertNotNil(TestEntityInt.first(in: viewContext, matching: predicate2))
     }
     
     func testFirstConfigured() {
@@ -78,7 +78,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         XCTAssertEqual(TestEntityString.count(in: viewContext), count)
         
         let predicate1 = TestEntityString.uniqueIDValue(equalTo: itemToDelete1.uniqueIDValue)
-        TestEntityString.delete(in: viewContext, predicate: predicate1)
+        TestEntityString.delete(in: viewContext, matching: predicate1)
         
         XCTAssertEqual(TestEntityString.count(in: viewContext), count-1)
         
@@ -88,7 +88,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         XCTAssertEqual(TestEntityInt.count(in: viewContext), count)
         
         let predicate2 = TestEntityInt.uniqueIDValue(equalTo: itemToDelete2.uniqueIDValue)
-        TestEntityInt.delete(in: viewContext, predicate: predicate2)
+        TestEntityInt.delete(in: viewContext, matching: predicate2)
         
         XCTAssertEqual(TestEntityInt.count(in: viewContext), count-1)
     }

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -15,11 +15,11 @@ class ManagedObjectTypeTests: CoreDataTests {
     func testFetchObject() {
         let id1 = UUID().uuidString
         TestEntityString.insertObject(with: id1, in: viewContext)
-        XCTAssertNotNil(TestEntityString.fetchObject(with: id1, in: viewContext))
+        XCTAssertNotNil(TestEntityString.fetchObject(with: id1, context: viewContext))
         
         let id2 = Int32.random(in: 0..<Int32.max)
         TestEntityInt.insertObject(with: id2, in: viewContext)
-        XCTAssertNotNil(TestEntityInt.fetchObject(with: id2, in: viewContext))
+        XCTAssertNotNil(TestEntityInt.fetchObject(with: id2, context: viewContext))
     }
     
     func testFirstMatchingPredicate() {

--- a/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
+++ b/Tests/PeakCoreDataTests/ManagedObjectTypeTests.swift
@@ -14,23 +14,23 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testFetchObject() {
         let id1 = UUID().uuidString
-        TestEntityString.insert(with: id1, context: viewContext)
-        XCTAssertNotNil(TestEntityString.fetch(with: id1, context: viewContext))
+        TestEntityString.insert(withID: id1, context: viewContext)
+        XCTAssertNotNil(TestEntityString.fetch(withID: id1, context: viewContext))
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        TestEntityInt.insert(with: id2, context: viewContext)
-        XCTAssertNotNil(TestEntityInt.fetch(with: id2, context: viewContext))
+        TestEntityInt.insert(withID: id2, context: viewContext)
+        XCTAssertNotNil(TestEntityInt.fetch(withID: id2, context: viewContext))
     }
     
     func testFirstMatchingPredicate() {
         let id1 = UUID().uuidString
-        TestEntityString.insert(with: id1, context: viewContext)
-        let predicate1 = TestEntityString.uniqueObjectPredicate(with: id1)
+        TestEntityString.insert(withID: id1, context: viewContext)
+        let predicate1 = TestEntityString.uniqueIDValue(equalTo: id1)
         XCTAssertNotNil(TestEntityString.first(in: viewContext, matching: predicate1))
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        TestEntityInt.insert(with: id2, context: viewContext)
-        let predicate2 = TestEntityInt.uniqueObjectPredicate(with: id2)
+        TestEntityInt.insert(withID: id2, context: viewContext)
+        let predicate2 = TestEntityInt.uniqueIDValue(equalTo: id2)
         XCTAssertNotNil(TestEntityInt.first(in: viewContext, matching: predicate2))
     }
     
@@ -77,7 +77,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         let itemToDelete1 = newObjects1.first!
         XCTAssertEqual(TestEntityString.count(in: viewContext), count)
         
-        let predicate1 = TestEntityString.uniqueObjectPredicate(with: itemToDelete1.uniqueIDValue)
+        let predicate1 = TestEntityString.uniqueIDValue(equalTo: itemToDelete1.uniqueIDValue)
         TestEntityString.delete(in: viewContext, matching: predicate1)
         
         XCTAssertEqual(TestEntityString.count(in: viewContext), count-1)
@@ -87,7 +87,7 @@ class ManagedObjectTypeTests: CoreDataTests {
         
         XCTAssertEqual(TestEntityInt.count(in: viewContext), count)
         
-        let predicate2 = TestEntityInt.uniqueObjectPredicate(with: itemToDelete2.uniqueIDValue)
+        let predicate2 = TestEntityInt.uniqueIDValue(equalTo: itemToDelete2.uniqueIDValue)
         TestEntityInt.delete(in: viewContext, matching: predicate2)
         
         XCTAssertEqual(TestEntityInt.count(in: viewContext), count-1)
@@ -95,13 +95,13 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testInsertOrFetchObject() {
         let id1 = UUID().uuidString
-        let item1 = TestEntityString.fetchOrInsert(with: id1, context: viewContext, cache: cache)
-        let item2 = TestEntityString.fetchOrInsert(with: id1, context: viewContext, cache: cache)
+        let item1 = TestEntityString.fetchOrInsert(withID: id1, context: viewContext, cache: cache)
+        let item2 = TestEntityString.fetchOrInsert(withID: id1, context: viewContext, cache: cache)
         XCTAssertEqual(item1, item2)
         
         let id2 = Int32.random(in: 0..<Int32.max)
-        let item3 = TestEntityInt.fetchOrInsert(with: id2, context: viewContext, cache: cache)
-        let item4 = TestEntityInt.fetchOrInsert(with: id2, context: viewContext, cache: cache)
+        let item3 = TestEntityInt.fetchOrInsert(withID: id2, context: viewContext, cache: cache)
+        let item4 = TestEntityInt.fetchOrInsert(withID: id2, context: viewContext, cache: cache)
         XCTAssertEqual(item3, item4)
     }
     
@@ -234,13 +234,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityString.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityString.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -254,13 +254,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityInt.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext) { entity in
+                TestEntityInt.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -274,13 +274,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityStringIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityString.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityString.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityString.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -294,13 +294,13 @@ class ManagedObjectTypeTests: CoreDataTests {
         let intermediateItems = createTestEntityIntIntermediates(count: insertCount)
         measure {
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityInt.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
             
             for intermediate in intermediateItems {
-                TestEntityInt.fetchOrInsert(with: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
+                TestEntityInt.fetchOrInsert(withID: intermediate.uniqueID, context: viewContext, cache: cache) { entity in
                     entity.title = intermediate.title
                 }
             }
@@ -311,7 +311,7 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testEncodingTestEntityToData() {
         let id = UUID().uuidString
-        let item1 = TestEntityString.fetchOrInsert(with: id, context: viewContext, cache: cache)
+        let item1 = TestEntityString.fetchOrInsert(withID: id, context: viewContext, cache: cache)
         item1.title = "Hello"
         
         let data = try! item1.encode(to: TestEntityStringJSON.self, encoder: JSONEncoder())
@@ -325,7 +325,7 @@ class ManagedObjectTypeTests: CoreDataTests {
     
     func testEncodingTestEntityIntToData() {
         let id = Int32.random(in: 0..<Int32.max)
-        let item1 = TestEntityInt.fetchOrInsert(with: id, context: viewContext, cache: cache)
+        let item1 = TestEntityInt.fetchOrInsert(withID: id, context: viewContext, cache: cache)
         item1.title = "Hello"
         
         let data = try! item1.encode(to: TestEntityIntJSON.self, encoder: JSONEncoder())

--- a/Tests/PeakCoreDataTests/OperationTests.swift
+++ b/Tests/PeakCoreDataTests/OperationTests.swift
@@ -405,7 +405,7 @@ class InsertThenDeleteOperation: CoreDataChangesetOperation {
         var testEntities: [TestEntityString] = []
         for item in 0..<insertCount {
             let id = UUID().uuidString
-            let newObject = TestEntityString.insertObject(with: id, in: context)
+            let newObject = TestEntityString.insertObject(with: id, context: context)
             newObject.title = "Item " + String(item)
             testEntities.append(newObject)
         }

--- a/Tests/PeakCoreDataTests/OperationTests.swift
+++ b/Tests/PeakCoreDataTests/OperationTests.swift
@@ -36,7 +36,7 @@ class OperationTests: CoreDataTests {
         var count = 0
         let finishOperation = BlockOperation {
             // Check that all the changes have made their way to the main context
-            let objectToUpdate = TestEntityString.fetchOrInsertObject(with: id, context: self.viewContext)
+            let objectToUpdate = TestEntityString.fetchOrInsert(with: id, context: self.viewContext)
             count = Int(objectToUpdate.count)
             finishExpectation.fulfill()
         }
@@ -384,7 +384,7 @@ class AddOneOperation: CoreDataOperation<Void> {
     }
     
     override func performWork(in context: NSManagedObjectContext) {
-        let objectToUpdate = TestEntityString.fetchOrInsertObject(with: uniqueKeyValue, context: context)
+        let objectToUpdate = TestEntityString.fetchOrInsert(with: uniqueKeyValue, context: context)
         objectToUpdate.count += 1
         saveAndFinish()
     }
@@ -405,7 +405,7 @@ class InsertThenDeleteOperation: CoreDataChangesetOperation {
         var testEntities: [TestEntityString] = []
         for item in 0..<insertCount {
             let id = UUID().uuidString
-            let newObject = TestEntityString.insertObject(with: id, context: context)
+            let newObject = TestEntityString.insert(with: id, context: context)
             newObject.title = "Item " + String(item)
             testEntities.append(newObject)
         }

--- a/Tests/PeakCoreDataTests/OperationTests.swift
+++ b/Tests/PeakCoreDataTests/OperationTests.swift
@@ -36,7 +36,7 @@ class OperationTests: CoreDataTests {
         var count = 0
         let finishOperation = BlockOperation {
             // Check that all the changes have made their way to the main context
-            let objectToUpdate = TestEntityString.fetchOrInsert(with: id, context: self.viewContext)
+            let objectToUpdate = TestEntityString.fetchOrInsert(withID: id, context: self.viewContext)
             count = Int(objectToUpdate.count)
             finishExpectation.fulfill()
         }
@@ -384,7 +384,7 @@ class AddOneOperation: CoreDataOperation<Void> {
     }
     
     override func performWork(in context: NSManagedObjectContext) {
-        let objectToUpdate = TestEntityString.fetchOrInsert(with: uniqueKeyValue, context: context)
+        let objectToUpdate = TestEntityString.fetchOrInsert(withID: uniqueKeyValue, context: context)
         objectToUpdate.count += 1
         saveAndFinish()
     }
@@ -405,7 +405,7 @@ class InsertThenDeleteOperation: CoreDataChangesetOperation {
         var testEntities: [TestEntityString] = []
         for item in 0..<insertCount {
             let id = UUID().uuidString
-            let newObject = TestEntityString.insert(with: id, context: context)
+            let newObject = TestEntityString.insert(withID: id, context: context)
             newObject.title = "Item " + String(item)
             testEntities.append(newObject)
         }

--- a/Tests/PeakCoreDataTests/OperationTests.swift
+++ b/Tests/PeakCoreDataTests/OperationTests.swift
@@ -36,7 +36,7 @@ class OperationTests: CoreDataTests {
         var count = 0
         let finishOperation = BlockOperation {
             // Check that all the changes have made their way to the main context
-            let objectToUpdate = TestEntityString.fetchOrInsertObject(with: id, in: self.viewContext)
+            let objectToUpdate = TestEntityString.fetchOrInsertObject(with: id, context: self.viewContext)
             count = Int(objectToUpdate.count)
             finishExpectation.fulfill()
         }
@@ -384,7 +384,7 @@ class AddOneOperation: CoreDataOperation<Void> {
     }
     
     override func performWork(in context: NSManagedObjectContext) {
-        let objectToUpdate = TestEntityString.fetchOrInsertObject(with: uniqueKeyValue, in: context)
+        let objectToUpdate = TestEntityString.fetchOrInsertObject(with: uniqueKeyValue, context: context)
         objectToUpdate.count += 1
         saveAndFinish()
     }


### PR DESCRIPTION
This updates method parameter names so they are more inline with Swift guidelines. So for example:

`insertOrUpdate(intermediates:in:with:configure`
becomes
`insertOrUpdate(intermediates:context:cache:configure`