### PR TITLE
Table View Section Header / Footer Decorators

### DIFF
--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedCollection.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedCollection.swift
@@ -25,27 +25,27 @@ public class FetchedCollection<T: NSManagedObject>: NSObject {
     private let dataProvider: FetchedDataProvider<FetchedCollection>
     
     public var sections: [NSFetchedResultsSectionInfo] {
-        return dataProvider.sections
+        dataProvider.sections
     }
     
     public func object(at indexPath: IndexPath) -> T {
-        return dataProvider.object(at: indexPath)
+        dataProvider.object(at: indexPath)
     }
     
     public func index(of object: T) -> IndexPath? {
-        return dataProvider.indexPath(forObject: object)
+        dataProvider.indexPath(forObject: object)
     }
     
     public var count: Int {
-        return dataProvider.fetchedObjectsCount
+        dataProvider.fetchedObjectsCount
     }
     
     public func snapshot() -> [T] {
-        return dataProvider.fetchedObjects
+        dataProvider.fetchedObjects
     }
     
     public var isEmpty: Bool {
-        return dataProvider.fetchedObjectsCount == 0
+        dataProvider.fetchedObjectsCount == 0
     }
     
     /// Create a new FetchedCollection.
@@ -75,15 +75,15 @@ public class FetchedCollection<T: NSManagedObject>: NSObject {
 extension FetchedCollection {
     
     public subscript (position: IndexPath) -> T {
-        return dataProvider.object(at: position)
+        dataProvider.object(at: position)
     }
     
     public subscript (position: (item: Int, section: Int)) -> T {
-        return dataProvider.object(at: IndexPath(item: position.item, section: position.section))
+        dataProvider.object(at: IndexPath(item: position.item, section: position.section))
     }
     
     public subscript (item: Int, section: Int) -> T {
-        return dataProvider.object(at: IndexPath(item: item, section: section))
+        dataProvider.object(at: IndexPath(item: item, section: section))
     }
 }
 

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedCollectionViewDataSource.swift
@@ -25,11 +25,11 @@ public protocol FetchedCollectionViewDataSourceDelegate: CollectionViewUpdatable
 }
 
 public extension FetchedCollectionViewDataSourceDelegate {
-    func reuseIdentifier(forHeaderAt indexPath: IndexPath) -> String? { return nil }
-    func reuseIdentifier(forFooterAt indexPath: IndexPath) -> String? { return nil }
+    func reuseIdentifier(forHeaderAt indexPath: IndexPath) -> String? { nil }
+    func reuseIdentifier(forFooterAt indexPath: IndexPath) -> String? { nil }
     func configureHeader(_ header: UICollectionReusableView, at indexPath: IndexPath) { }
     func configureFooter(_ footer: UICollectionReusableView, at indexPath: IndexPath) { }
-    func canMoveItem(at indexPath: IndexPath) -> Bool { return false }
+    func canMoveItem(at indexPath: IndexPath) -> Bool { false }
     func moveItem(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) { }
 }
 
@@ -47,27 +47,27 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     public var onDidChangeContent: (() -> Void)?
     
     public var cacheName: String? {
-        return dataProvider.cacheName
+        dataProvider.cacheName
     }
     
     public var fetchedObjectsCount: Int {
-        return dataProvider.fetchedObjectsCount
+        dataProvider.fetchedObjectsCount
     }
     
     public var isEmpty: Bool {
-        return dataProvider.isEmpty
+        dataProvider.isEmpty
     }
     
     public var numberOfSections: Int {
-        return dataProvider.numberOfSections
+        dataProvider.numberOfSections
     }
     
     public var sectionIndexTitles: [String] {
-        return dataProvider.sectionIndexTitles
+        dataProvider.sectionIndexTitles
     }
     
     public var sectionNameKeyPath: String? {
-        return dataProvider.sectionNameKeyPath
+        dataProvider.sectionNameKeyPath
     }
     
     public required init(collectionView: UICollectionView, fetchedResultsController: NSFetchedResultsController<Object>, delegate: Delegate) {
@@ -80,19 +80,19 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     }
     
     public func indexPath(forObject object: Object) -> IndexPath? {
-        return dataProvider.indexPath(forObject: object)
+        dataProvider.indexPath(forObject: object)
     }
     
     public func name(in section: Int) -> String? {
-        return dataProvider.name(in: section)
+        dataProvider.name(in: section)
     }
     
     public func numberOfItems(in section: Int) -> Int {
-        return dataProvider.numberOfItems(in: section)
+        dataProvider.numberOfItems(in: section)
     }
     
     public func object(at indexPath: IndexPath) -> Object {
-        return dataProvider.object(at: indexPath)
+        dataProvider.object(at: indexPath)
     }
     
     public func performFetch() {
@@ -100,11 +100,11 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     }
     
     public func section(forSectionIndexTitle title: String, at index: Int) -> Int {
-        return dataProvider.section(forSectionIndexTitle: title, at: index)
+        dataProvider.section(forSectionIndexTitle: title, at: index)
     }
     
     public func sectionInfo(forSection section: Int) -> NSFetchedResultsSectionInfo {
-        return dataProvider.sectionInfo(forSection: section)
+        dataProvider.sectionInfo(forSection: section)
     }
     
     public func reconfigureFetchRequest(_ configure: (NSFetchRequest<Object>) -> Void) {
@@ -122,11 +122,11 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     // MARK: UICollectionViewDataSource
     
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
-        return numberOfSections
+        numberOfSections
     }
     
     public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return numberOfItems(in: section)
+        numberOfItems(in: section)
     }
     
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -164,7 +164,7 @@ public class FetchedCollectionViewDataSource<Delegate: FetchedCollectionViewData
     }
     
     public func collectionView(_ collectionView: UICollectionView, canMoveItemAt indexPath: IndexPath) -> Bool {
-        return delegate.canMoveItem(at: indexPath)
+        delegate.canMoveItem(at: indexPath)
     }
     
     public func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedDataProvider.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedDataProvider.swift
@@ -26,7 +26,7 @@ public protocol HasEmptyView: AnyObject {
 }
 
 public extension HasEmptyView {
-    var emptyView: UIView? { return nil }
+    var emptyView: UIView? { nil }
 }
 
 protocol FetchedDataProviderDelegate: AnyObject {
@@ -39,7 +39,7 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     typealias Object = Delegate.Object
     
     var cacheName: String? {
-        return fetchedResultsController.cacheName
+        fetchedResultsController.cacheName
     }
     
     var fetchedObjectsCount: Int {
@@ -51,27 +51,27 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     }
     
     var fetchedObjects: [Object] {
-        return fetchedResultsController.fetchedObjects ?? []
+        fetchedResultsController.fetchedObjects ?? []
     }
     
     var isEmpty: Bool {
-        return fetchedObjectsCount == 0
+        fetchedObjectsCount == 0
     }
     
     var sections: [NSFetchedResultsSectionInfo] {
-        return fetchedResultsController.sections ?? []
+        fetchedResultsController.sections ?? []
     }
 
     var numberOfSections: Int {
-        return sections.count
+        sections.count
     }
     
     var sectionIndexTitles: [String] {
-        return fetchedResultsController.sectionIndexTitles
+        fetchedResultsController.sectionIndexTitles
     }
     
     var sectionNameKeyPath: String? {
-        return fetchedResultsController.sectionNameKeyPath
+        fetchedResultsController.sectionNameKeyPath
     }
     
     private let fetchedResultsController: NSFetchedResultsController<Object>
@@ -93,7 +93,7 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     }
     
     func indexPath(forObject object: Object) -> IndexPath? {
-        return fetchedResultsController.indexPath(forObject: object)
+        fetchedResultsController.indexPath(forObject: object)
     }
     
     func name(in section: Int) -> String? {
@@ -107,15 +107,15 @@ class FetchedDataProvider<Delegate: FetchedDataProviderDelegate>: NSObject, NSFe
     }
     
     func object(at indexPath: IndexPath) -> Object {
-        return fetchedResultsController.object(at: indexPath)
+        fetchedResultsController.object(at: indexPath)
     }
     
     func section(forSectionIndexTitle title: String, at index: Int) -> Int {
-        return fetchedResultsController.section(forSectionIndexTitle: title, at: index)
+        fetchedResultsController.section(forSectionIndexTitle: title, at: index)
     }
     
     func sectionInfo(forSection section: Int) -> NSFetchedResultsSectionInfo {
-        return fetchedResultsController.sections![section] as NSFetchedResultsSectionInfo
+        fetchedResultsController.sections![section] as NSFetchedResultsSectionInfo
     }
     
     func reconfigureFetchRequest(_ configure: (NSFetchRequest<Object>) -> Void) {

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
@@ -37,6 +37,8 @@ public extension FetchedTableViewDataSourceDelegate {
 public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDelegate>: NSObject, UITableViewDataSource, UITableViewDelegate {
     public typealias Object = Delegate.Object
     public typealias Cell = Delegate.Cell
+    public typealias Header = Delegate.Header
+    public typealias Footer = Delegate.Footer
     
     private let tableView: UITableView
     private let dataProvider: FetchedDataProvider<FetchedTableViewDataSource>
@@ -193,10 +195,10 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         
-        guard let identifier = delegate.identifier(forHeaderIn: section),
-              let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else { return nil }
+        guard let identifier = delegate.identifier(forHeaderIn: section) else { return nil }
+        guard let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) as? Header else { fatalError("Unexpected header type at \(section)") }
         
-        delegate.configure(header: view, for: section)
+        delegate.configureHeader(view, for: section)
         
         return view
     }
@@ -204,10 +206,10 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     public func tableView(_ tableView: UITableView,
                           viewForFooterInSection section: Int) -> UIView? {
         
-        guard let identifier = delegate.identifier(forFooterIn: section),
-              let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else { return nil }
+        guard let identifier = delegate.identifier(forFooterIn: section) else { return nil }
+        guard let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) as? Footer else { fatalError("Unexpected footer type at \(section)") }
         
-        delegate.configure(footer: view, for: section)
+        delegate.configureFooter(view, for: section)
         
         return view
     }

--- a/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/FetchedTableViewDataSource.swift
@@ -11,7 +11,8 @@
 import UIKit
 import CoreData
 
-public protocol FetchedTableViewDataSourceDelegate: TableViewUpdatable, HasEmptyView {
+public protocol FetchedTableViewDataSourceDelegate: TableViewDecoratable, TableViewUpdatable, HasEmptyView {
+    // Required
     func identifier(forCellAt indexPath: IndexPath) -> String
     // Optional
     var rowAnimation: UITableView.RowAnimation { get }
@@ -24,16 +25,16 @@ public protocol FetchedTableViewDataSourceDelegate: TableViewUpdatable, HasEmpty
 }
 
 public extension FetchedTableViewDataSourceDelegate {
-    var rowAnimation: UITableView.RowAnimation { return .automatic }
-    func titleForHeader(in section: Int) -> String? { return nil }
-    func titleForFooter(in section: Int) -> String? { return nil }
-    func canEditRow(at indexPath: IndexPath) -> Bool { return false }
+    var rowAnimation: UITableView.RowAnimation { .automatic }
+    func titleForHeader(in section: Int) -> String? { nil }
+    func titleForFooter(in section: Int) -> String? { nil }
+    func canEditRow(at indexPath: IndexPath) -> Bool { false }
     func commit(editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) { }
-    func canMoveRow(at indexPath: IndexPath) -> Bool { return false }
+    func canMoveRow(at indexPath: IndexPath) -> Bool { false }
     func moveRow(at sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) { }
 }
 
-public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDelegate>: NSObject, UITableViewDataSource {
+public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDelegate>: NSObject, UITableViewDataSource, UITableViewDelegate {
     public typealias Object = Delegate.Object
     public typealias Cell = Delegate.Cell
     
@@ -46,27 +47,27 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     public var onDidChangeContent: (() -> Void)?
     
     public var cacheName: String? {
-        return dataProvider.cacheName
+        dataProvider.cacheName
     }
     
     public var fetchedObjectsCount: Int {
-        return dataProvider.fetchedObjectsCount
+        dataProvider.fetchedObjectsCount
     }
     
     public var isEmpty: Bool {
-        return dataProvider.isEmpty
+        dataProvider.isEmpty
     }
     
     public var numberOfSections: Int {
-        return dataProvider.numberOfSections
+        dataProvider.numberOfSections
     }
     
     public var sectionIndexTitles: [String] {
-        return dataProvider.sectionIndexTitles
+        dataProvider.sectionIndexTitles
     }
     
     public var sectionNameKeyPath: String? {
-        return dataProvider.sectionNameKeyPath
+        dataProvider.sectionNameKeyPath
     }
     
     public required init(tableView: UITableView, fetchedResultsController: NSFetchedResultsController<Object>, delegate: Delegate) {
@@ -75,23 +76,24 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
         self.dataProvider = FetchedDataProvider(fetchedResultsController: fetchedResultsController)
         super.init()
         tableView.dataSource = self
+        tableView.delegate = self
         dataProvider.delegate = self
     }
     
     public func indexPath(forObject object: Object) -> IndexPath? {
-        return dataProvider.indexPath(forObject: object)
+        dataProvider.indexPath(forObject: object)
     }
     
     public func name(in section: Int) -> String? {
-        return dataProvider.name(in: section)
+        dataProvider.name(in: section)
     }
     
     public func numberOfItems(in section: Int) -> Int {
-        return dataProvider.numberOfItems(in: section)
+        dataProvider.numberOfItems(in: section)
     }
     
     public func object(at indexPath: IndexPath) -> Object {
-        return dataProvider.object(at: indexPath)
+        dataProvider.object(at: indexPath)
     }
     
     public func performFetch() {
@@ -99,11 +101,11 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func section(forSectionIndexTitle title: String, at index: Int) -> Int {
-        return dataProvider.section(forSectionIndexTitle: title, at: index)
+        dataProvider.section(forSectionIndexTitle: title, at: index)
     }
     
     public func sectionInfo(forSection section: Int) -> NSFetchedResultsSectionInfo {
-        return dataProvider.sectionInfo(forSection: section)
+        dataProvider.sectionInfo(forSection: section)
     }
     
     public func reconfigureFetchRequest(_ configure: (NSFetchRequest<Object>) -> Void) {
@@ -121,32 +123,36 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     // MARK: UITableViewDataSource
     
     public func numberOfSections(in tableView: UITableView) -> Int {
-        return numberOfSections
+        numberOfSections
     }
     
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return numberOfItems(in: section)
+        numberOfItems(in: section)
     }
     
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
         let cellIdentifier = delegate.identifier(forCellAt: indexPath)
+        
         guard let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath) as? Cell else {
             fatalError("Unexpected cell type at \(indexPath)")
         }
+        
         delegate.configure(cell, with: object(at: indexPath))
+        
         return cell
     }
     
     public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return delegate.titleForHeader(in: section)
+        delegate.titleForHeader(in: section)
     }
     
     public func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        return delegate.titleForFooter(in: section)
+        delegate.titleForFooter(in: section)
     }
     
     public func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return delegate.canEditRow(at: indexPath)
+        delegate.canEditRow(at: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
@@ -154,7 +160,7 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return delegate.canMoveRow(at: indexPath)
+        delegate.canMoveRow(at: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
@@ -162,11 +168,64 @@ public class FetchedTableViewDataSource<Delegate: FetchedTableViewDataSourceDele
     }
     
     public func sectionIndexTitles(for tableView: UITableView) -> [String]? {
-        return showSectionIndexTitles ? sectionIndexTitles : nil
+        showSectionIndexTitles ? sectionIndexTitles : nil
     }
     
     public func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
-        return section(forSectionIndexTitle: title, at: index)
+        section(forSectionIndexTitle: title, at: index)
+    }
+    
+    // MARK: UITableViewDelegate
+    
+    public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        
+        tableView.selectRow(at: indexPath, animated: animateUpdates, scrollPosition: .none)
+        
+        delegate.didSelect(object: object(at: indexPath), at: indexPath)
+    }
+    
+    public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        
+        tableView.deselectRow(at: indexPath, animated: animateUpdates)
+        
+        delegate.didDeselect(object: object(at: indexPath), at: indexPath)
+    }
+    
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        
+        guard let identifier = delegate.identifier(forHeaderIn: section),
+              let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else { return nil }
+        
+        delegate.configure(header: view, for: section)
+        
+        return view
+    }
+    
+    public func tableView(_ tableView: UITableView,
+                          viewForFooterInSection section: Int) -> UIView? {
+        
+        guard let identifier = delegate.identifier(forFooterIn: section),
+              let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: identifier) else { return nil }
+        
+        delegate.configure(footer: view, for: section)
+        
+        return view
+    }
+    
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        delegate.heightForHeader(in: section)
+    }
+    
+    public func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        delegate.heightForFooter(in: section)
+    }
+    
+    public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
+        delegate.willDisplay(headerView: view, for: section)
+    }
+    
+    public func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        delegate.willDisplay(footerView: view, for: section)
     }
 }
 

--- a/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
+++ b/Sources/PeakCoreData/Fetched Data Sources/TableViewUpdatable.swift
@@ -14,7 +14,19 @@ import UIKit
 public protocol TableViewUpdatable: AnyObject {
     associatedtype Object: NSManagedObject
     associatedtype Cell: UITableViewCell
+    
+    // Required
     func configure(_ cell: Cell, with object: Object)
+    
+    // Optional
+    func didSelect(object: Object, at indexPath: IndexPath)
+    func didDeselect(object: Object, at indexPath: IndexPath)
+}
+
+extension TableViewUpdatable {
+    
+    public func didSelect(object: Object, at indexPath: IndexPath) { }
+    public func didDeselect(object: Object, at indexPath: IndexPath) { }
 }
 
 extension TableViewUpdatable {

--- a/Sources/PeakCoreData/Observers/Notifications/ContextDidSaveNotification.swift
+++ b/Sources/PeakCoreData/Observers/Notifications/ContextDidSaveNotification.swift
@@ -17,15 +17,15 @@ public struct ContextDidSaveNotification {
     }
     
     public var insertedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSInsertedObjectsKey)
+        objects(forKey: NSInsertedObjectsKey)
     }
     
     public var updatedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSUpdatedObjectsKey)
+        objects(forKey: NSUpdatedObjectsKey)
     }
     
     public var deletedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSDeletedObjectsKey)
+        objects(forKey: NSDeletedObjectsKey)
     }
     
     public var managedObjectContext: NSManagedObjectContext {
@@ -38,6 +38,6 @@ public struct ContextDidSaveNotification {
     private let notification: Notification
     
     private func objects(forKey key: String) -> Set<NSManagedObject> {
-        return (notification.userInfo?[key] as? Set<NSManagedObject>) ?? []
+        (notification.userInfo?[key] as? Set<NSManagedObject>) ?? []
     }
 }

--- a/Sources/PeakCoreData/Observers/Notifications/ObjectDidChangeNotification.swift
+++ b/Sources/PeakCoreData/Observers/Notifications/ObjectDidChangeNotification.swift
@@ -16,27 +16,27 @@ public struct ObjectsDidChangeNotification {
     }
     
     public var insertedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSInsertedObjectsKey)
+        objects(forKey: NSInsertedObjectsKey)
     }
     
     public var updatedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSUpdatedObjectsKey)
+        objects(forKey: NSUpdatedObjectsKey)
     }
     
     public var deletedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSDeletedObjectsKey)
+        objects(forKey: NSDeletedObjectsKey)
     }
     
     public var refreshedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSRefreshedObjectsKey)
+        objects(forKey: NSRefreshedObjectsKey)
     }
     
     public var invalidatedObjects: Set<NSManagedObject> {
-        return objects(forKey: NSInvalidatedObjectsKey)
+        objects(forKey: NSInvalidatedObjectsKey)
     }
     
     public var invalidatedAllObjects: Bool {
-        return (notification as Notification).userInfo?[NSInvalidatedAllObjectsKey] != nil
+        (notification as Notification).userInfo?[NSInvalidatedAllObjectsKey] != nil
     }
     
     public var managedObjectContext: NSManagedObjectContext {
@@ -49,6 +49,6 @@ public struct ObjectsDidChangeNotification {
     private let notification: Notification
     
     private func objects(forKey key: String) -> Set<NSManagedObject> {
-        return (notification.userInfo?[key] as? Set<NSManagedObject>) ?? []
+        (notification.userInfo?[key] as? Set<NSManagedObject>) ?? []
     }
 }

--- a/Sources/PeakCoreData/Operations/Changeset.swift
+++ b/Sources/PeakCoreData/Operations/Changeset.swift
@@ -16,6 +16,6 @@ public struct Changeset {
     public let inserted: Set<NSManagedObjectID>
     public let updated: Set<NSManagedObjectID>
     public var all: Set<NSManagedObjectID> {
-        return inserted.union(updated)
+        inserted.union(updated)
     }
 }

--- a/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
+++ b/Sources/PeakCoreData/Protocols/ManagedObjectType.swift
@@ -21,8 +21,8 @@ public extension ManagedObjectType {
     typealias FetchRequestConfigurationBlock = (NSFetchRequest<Self>) -> Void
     typealias ManagedObjectConfigurationBlock = (Self) -> Void
     
-    static var entityName: String { return String(describing: self) }
-    static var defaultSortDescriptors: [NSSortDescriptor] { return [] }
+    static var entityName: String { String(describing: self) }
+    static var defaultSortDescriptors: [NSSortDescriptor] { [] }
     
     /**
      - parameter context:       The context to use.

--- a/Sources/PeakCoreData/Protocols/PersistentContainerSettable.swift
+++ b/Sources/PeakCoreData/Protocols/PersistentContainerSettable.swift
@@ -15,7 +15,7 @@ public protocol PersistentContainerSettable: AnyObject {
 public extension PersistentContainerSettable {
     
     var viewContext: NSManagedObjectContext {
-        return persistentContainer.viewContext
+        persistentContainer.viewContext
     }
     
     func saveViewContext() {

--- a/Sources/PeakCoreData/Protocols/TableViewDecoratable.swift
+++ b/Sources/PeakCoreData/Protocols/TableViewDecoratable.swift
@@ -26,8 +26,8 @@ public extension TableViewDecoratable {
     
     func identifier(forHeaderIn section: Int) -> String? { nil }
     func identifier(forFooterIn section: Int) -> String? { nil }
-    func heightForHeader(in section: Int) -> CGFloat { .leastNormalMagnitude}
-    func heightForFooter(in section: Int) -> CGFloat { .leastNormalMagnitude}
+    func heightForHeader(in section: Int) -> CGFloat { .leastNormalMagnitude }
+    func heightForFooter(in section: Int) -> CGFloat { .leastNormalMagnitude }
     func willDisplay(headerView: UIView, for section: Int) { }
     func willDisplay(footerView: UIView, for section: Int) { }
     func configure(header view: UIView, for section: Int) { }

--- a/Sources/PeakCoreData/Protocols/TableViewDecoratable.swift
+++ b/Sources/PeakCoreData/Protocols/TableViewDecoratable.swift
@@ -1,0 +1,37 @@
+//
+//  TableViewDecoratable.swift
+//  PeakCoreData
+//
+//  Created by Zack Brown on 17/03/2025.
+//
+
+#if canImport(UIKit)
+
+import UIKit
+
+public protocol TableViewDecoratable: AnyObject {
+    
+    // Optional
+    func identifier(forHeaderIn section: Int) -> String?
+    func identifier(forFooterIn section: Int) -> String?
+    func heightForHeader(in section: Int) -> CGFloat
+    func heightForFooter(in section: Int) -> CGFloat
+    func willDisplay(headerView: UIView, for section: Int)
+    func willDisplay(footerView: UIView, for section: Int)
+    func configure(header view: UIView, for section: Int)
+    func configure(footer view: UIView, for section: Int)
+}
+
+public extension TableViewDecoratable {
+    
+    func identifier(forHeaderIn section: Int) -> String? { nil }
+    func identifier(forFooterIn section: Int) -> String? { nil }
+    func heightForHeader(in section: Int) -> CGFloat { .leastNormalMagnitude}
+    func heightForFooter(in section: Int) -> CGFloat { .leastNormalMagnitude}
+    func willDisplay(headerView: UIView, for section: Int) { }
+    func willDisplay(footerView: UIView, for section: Int) { }
+    func configure(header view: UIView, for section: Int) { }
+    func configure(footer view: UIView, for section: Int) { }
+}
+
+#endif

--- a/Sources/PeakCoreData/Protocols/TableViewDecoratable.swift
+++ b/Sources/PeakCoreData/Protocols/TableViewDecoratable.swift
@@ -10,7 +10,8 @@
 import UIKit
 
 public protocol TableViewDecoratable: AnyObject {
-    
+    associatedtype Header: UITableViewHeaderFooterView
+    associatedtype Footer: UITableViewHeaderFooterView
     // Optional
     func identifier(forHeaderIn section: Int) -> String?
     func identifier(forFooterIn section: Int) -> String?
@@ -18,8 +19,8 @@ public protocol TableViewDecoratable: AnyObject {
     func heightForFooter(in section: Int) -> CGFloat
     func willDisplay(headerView: UIView, for section: Int)
     func willDisplay(footerView: UIView, for section: Int)
-    func configure(header view: UIView, for section: Int)
-    func configure(footer view: UIView, for section: Int)
+    func configureHeader(_ header: Header, for section: Int)
+    func configureFooter(_ footer: Footer, for section: Int)
 }
 
 public extension TableViewDecoratable {
@@ -30,8 +31,8 @@ public extension TableViewDecoratable {
     func heightForFooter(in section: Int) -> CGFloat { .leastNormalMagnitude }
     func willDisplay(headerView: UIView, for section: Int) { }
     func willDisplay(footerView: UIView, for section: Int) { }
-    func configure(header view: UIView, for section: Int) { }
-    func configure(footer view: UIView, for section: Int) { }
+    func configureHeader(_ header: UITableViewHeaderFooterView, for section: Int) { }
+    func configureFooter(_ footer: UITableViewHeaderFooterView, for section: Int) { }
 }
 
 #endif


### PR DESCRIPTION
# Description

Implements additional `UITableViewDelegate` methods within `FetchedTableViewDataSource` to delegate responsibility for dequeuing `UITableViewHeaderFooterView` section headers / footers.  

- Adds `TableViewDecoratable` protocol.
- Implements appropriate `UITableViewDelegate` methods with delegation to associated `TableViewDecoratable` mapped methods.

## Scope of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] The project builds successfully without generating errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] No force unwrapping and all optionals are guarded against / safely checked