### PR TITLE
Remove performAndWait overload

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "PeakCoreData",
-    platforms: [.iOS(.v12),
+    platforms: [.iOS(.v15),
                 .macOS(.v14)],
     products: [
         .library(

--- a/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
+++ b/Sources/PeakCoreData/Helpers/NSManagedObjectContext.swift
@@ -9,42 +9,6 @@
 import CoreData
 
 extension NSManagedObjectContext {
-    
-    typealias VoidBlock = () -> Void
-    typealias VoidBlockBlock = (VoidBlock) -> Void
-    
-    /// Helper function for convincing the type checker that
-    /// the rethrows invariant holds for performAndWait.
-    ///
-    /// - Source: https://github.com/apple/swift/blob/bb157a070ec6534e4b534456d208b03adc07704b/stdlib/public/SDK/Dispatch/Queue.swift#L228-L249
-    /// - Source: https://oleb.net/blog/2018/02/performandwait/
-    @discardableResult
-    public func performAndWait<T>(_ block: () throws -> T) rethrows -> T {
-        
-        func _helper<T>(fn: VoidBlockBlock, execute work: () throws -> T, rescue: ((Error) throws -> (T))) rethrows -> T {
-            var r: T?
-            var e: Error?
-            withoutActuallyEscaping(work) { _work in
-                fn {
-                    do {
-                        r = try _work()
-                    } catch {
-                        e = error
-                    }
-                }
-            }
-            if let error = e {
-                return try rescue(error)
-            }
-            guard let result = r else {
-                fatalError("Failed to generate a result or throw error.")
-            }
-            return result
-        }
-        
-        return try _helper(fn: performAndWait(_:), execute: block, rescue: { throw $0 } )
-    }
-    
     /**
      Batch deletes all objects for all entities in the data model. An optional array of
      `NSManagedObjectContext` can be provided into which the deletions can be merged using the


### PR DESCRIPTION
Removes the rethrowable invariant for `performAndWait` helper method on `NSManagedObjectContext`.

Originally detailed here: https://oleb.net/blog/2018/02/performandwait/

This is no longer needed as iOS 15 introduced this method as part of the base SDK. Recent Swift and iOS updates now throw errors when building due to abmiguity of the overloaded method signatures.

Unit tests still pass after removing and no obvious / major errors have been exhibited in apps that utilise this library.